### PR TITLE
Add OpenAPI Configuration Bean to better describe the Beacons API

### DIFF
--- a/src/main/java/uk/gov/mca/beacons/service/configuration/OpenApiConfig.java
+++ b/src/main/java/uk/gov/mca/beacons/service/configuration/OpenApiConfig.java
@@ -4,31 +4,30 @@ import io.swagger.v3.oas.models.ExternalDocumentation;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class OpenApiConfig {
 
+  private static final String GITHUB_LICENSE_SUFFIX = "/blob/main/LICENSE";
+
   @Bean
-  public OpenAPI beaconsOpenApiConfig() {
+  public OpenAPI beaconsOpenApiConfig(
+    @Value("${beacons.openapi.github.url}") String gitHubUrl
+  ) {
     return new OpenAPI()
       .info(
         new Info()
           .title("Beacons API")
           .description("OpenAPI 3 definition for the Beacons API")
           .license(
-            new License()
-              .name(("MIT"))
-              .url(
-                "https://github.com/mcagov/beacons-service/blob/main/LICENCE"
-              )
+            new License().name(("MIT")).url(gitHubUrl + GITHUB_LICENSE_SUFFIX)
           )
       )
       .externalDocs(
-        new ExternalDocumentation()
-          .description("GitHub")
-          .url("https://github.com/mcagov/beacons-service")
+        new ExternalDocumentation().description("GitHub").url(gitHubUrl)
       );
   }
 }

--- a/src/main/java/uk/gov/mca/beacons/service/configuration/OpenApiConfig.java
+++ b/src/main/java/uk/gov/mca/beacons/service/configuration/OpenApiConfig.java
@@ -1,0 +1,34 @@
+package uk.gov.mca.beacons.service.configuration;
+
+import io.swagger.v3.oas.models.ExternalDocumentation;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+  @Bean
+  public OpenAPI beaconsOpenApiConfig() {
+    return new OpenAPI()
+      .info(
+        new Info()
+          .title("Beacons API")
+          .description("OpenAPI 3 definition for the Beacons API")
+          .license(
+            new License()
+              .name(("MIT"))
+              .url(
+                "https://github.com/mcagov/beacons-service/blob/main/LICENCE"
+              )
+          )
+      )
+      .externalDocs(
+        new ExternalDocumentation()
+          .description("GitHub")
+          .url("https://github.com/mcagov/beacons-service")
+      );
+  }
+}

--- a/src/main/java/uk/gov/mca/beacons/service/registrations/BeaconController.java
+++ b/src/main/java/uk/gov/mca/beacons/service/registrations/BeaconController.java
@@ -1,5 +1,6 @@
 package uk.gov.mca.beacons.service.registrations;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -8,6 +9,7 @@ import uk.gov.mca.beacons.service.model.Beacon;
 
 @RestController
 @RequestMapping("/beacons")
+@Tag(name = "Beacons Controller")
 public class BeaconController {
 
   @GetMapping(value = "/{hexId}")

--- a/src/main/java/uk/gov/mca/beacons/service/registrations/RegistrationsController.java
+++ b/src/main/java/uk/gov/mca/beacons/service/registrations/RegistrationsController.java
@@ -1,5 +1,6 @@
 package uk.gov.mca.beacons.service.registrations;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -11,9 +12,9 @@ import uk.gov.mca.beacons.service.model.Registration;
 
 @RestController
 @RequestMapping("/registrations")
+@Tag(name = "Registrations Controller")
 public class RegistrationsController {
 
-  @Autowired
   private final RegistrationsService registrationsService;
 
   @Autowired

--- a/src/main/java/uk/gov/mca/beacons/service/registrations/RegistrationsService.java
+++ b/src/main/java/uk/gov/mca/beacons/service/registrations/RegistrationsService.java
@@ -1,7 +1,6 @@
 package uk.gov.mca.beacons.service.registrations;
 
 import java.net.URI;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import uk.gov.mca.beacons.service.model.Registration;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,3 +10,8 @@ spring:
 server:
   servlet:
     context-path: /spring-api
+
+beacons:
+  openapi:
+    github:
+      url: https://github.com/mcagov/beacons-service

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -5,3 +5,8 @@ spring:
     url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/beacons}
     username: ${SPRING_DATASOURCE_USER:beacons_service}
     password: ${SPRING_DATASOURCE_PASSWORD:password}
+
+beacons:
+  openapi:
+    github:
+      url: https://github.com/mcagov/beacons-service


### PR DESCRIPTION
## Context

- Add OpenAPI configuration bean to customise the description of the beacons API

## Changes in this pull request

- Adds descriptions on controllers
- Adds link to beacons service repository
- Adds link to MIT license in GitHub

## Guidance to review

See screenshots of update:
![image](https://user-images.githubusercontent.com/76042279/112624819-004ed580-8e26-11eb-959b-83a23faea8b9.png)

