### PR TITLE
Expose Git Info to actuator endpoint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,6 +82,7 @@ jobs:
       - name: Build and Push
         uses: docker/build-push-action@v2
         with:
+          context: .
           push: true
           tags: ${{ secrets.AWS_ECR_REGISTRY }}/${{ secrets.AWS_ECR_REPOSITORY }}:${{ github.sha }}
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,10 +14,6 @@ repositories {
 	mavenCentral()
 }
 
-springBoot {
-	buildInfo()
-}
-
 testlogger {
 	theme 'mocha'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -10,12 +10,12 @@ group = 'uk.gov.mca'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
-repositories {
-	mavenCentral()
-}
-
 testlogger {
 	theme 'mocha'
+}
+
+repositories {
+	mavenCentral()
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -10,16 +10,16 @@ group = 'uk.gov.mca'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
+repositories {
+	mavenCentral()
+}
+
 springBoot {
 	buildInfo()
 }
 
 testlogger {
 	theme 'mocha'
-}
-
-repositories {
-	mavenCentral()
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'java'
 	id 'com.adarshr.test-logger' version '2.1.1'
+	id 'com.gorylenko.gradle-git-properties' version '2.2.4'
 }
 
 group = 'uk.gov.mca'

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,10 @@ group = 'uk.gov.mca'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
+springBoot {
+	buildInfo()
+}
+
 testlogger {
 	theme 'mocha'
 }

--- a/src/test/java/uk/gov/mca/beacons/service/BeaconsRegistrationServiceIntegrationTest.java
+++ b/src/test/java/uk/gov/mca/beacons/service/BeaconsRegistrationServiceIntegrationTest.java
@@ -28,8 +28,8 @@ class BeaconsRegistrationServiceIntegrationTest {
   }
 
   @Test
-  void actuatorGitInfoEndpoint() {
-    makeGet(ACTUATOR_INFO_ENDPOINT).expectBody().jsonPath("$.gitt").exists();
+  void actuatorGitInfoEndpointShouldReturnGitInfo() {
+    makeGet(ACTUATOR_INFO_ENDPOINT).expectBody().jsonPath("$.git").exists();
   }
 
   private WebTestClient.ResponseSpec makeGet(String url) {

--- a/src/test/java/uk/gov/mca/beacons/service/BeaconsRegistrationServiceIntegrationTest.java
+++ b/src/test/java/uk/gov/mca/beacons/service/BeaconsRegistrationServiceIntegrationTest.java
@@ -24,15 +24,20 @@ class BeaconsRegistrationServiceIntegrationTest {
 
   @Test
   void actuatorEndpointShouldReturnUp() {
-    makeGet(ACTUATOR_HEALTH_ENDPOINT).expectBody().json("{\"status\": \"UP\"}");
+    makeGetRequest(ACTUATOR_HEALTH_ENDPOINT)
+      .expectBody()
+      .json("{\"status\": \"UP\"}");
   }
 
   @Test
   void actuatorGitInfoEndpointShouldReturnGitInfo() {
-    makeGet(ACTUATOR_INFO_ENDPOINT).expectBody().jsonPath("$.git").exists();
+    makeGetRequest(ACTUATOR_INFO_ENDPOINT)
+      .expectBody()
+      .jsonPath("$.git")
+      .exists();
   }
 
-  private WebTestClient.ResponseSpec makeGet(String url) {
+  private WebTestClient.ResponseSpec makeGetRequest(String url) {
     return webTestClient
       .get()
       .uri(url)

--- a/src/test/java/uk/gov/mca/beacons/service/BeaconsRegistrationServiceIntegrationTest.java
+++ b/src/test/java/uk/gov/mca/beacons/service/BeaconsRegistrationServiceIntegrationTest.java
@@ -10,7 +10,11 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 @AutoConfigureWebTestClient
 class BeaconsRegistrationServiceIntegrationTest {
 
-  private static final String ACTUATOR_HEALTH_ENDPOINT = "/actuator/health";
+  private static final String ACTUATOR_ENDPOINT = "/actuator";
+  private static final String ACTUATOR_HEALTH_ENDPOINT =
+    ACTUATOR_ENDPOINT + "/health";
+  private static final String ACTUATOR_INFO_ENDPOINT =
+    ACTUATOR_ENDPOINT + "/info";
 
   @Autowired
   private WebTestClient webTestClient;
@@ -20,13 +24,20 @@ class BeaconsRegistrationServiceIntegrationTest {
 
   @Test
   void actuatorEndpointShouldReturnUp() {
-    webTestClient
+    makeGet(ACTUATOR_HEALTH_ENDPOINT).expectBody().json("{\"status\": \"UP\"}");
+  }
+
+  @Test
+  void actuatorGitInfoEndpoint() {
+    makeGet(ACTUATOR_INFO_ENDPOINT).expectBody().jsonPath("$.gitt").exists();
+  }
+
+  private WebTestClient.ResponseSpec makeGet(String url) {
+    return webTestClient
       .get()
-      .uri(ACTUATOR_HEALTH_ENDPOINT)
+      .uri(url)
       .exchange()
       .expectStatus()
-      .is2xxSuccessful()
-      .expectBody()
-      .json("{\"status\": \"UP\"}");
+      .is2xxSuccessful();
   }
 }


### PR DESCRIPTION
## Context

- @zackads and I were deploying the latest version of the service for the Show & Tell on Friday and noticed the deployment had not gone through
- Have added a dependency based on Spring Boot's guide for the Actuator dependency which will expose the git info in the build via the `/actuator/info` endpoint

## Changes in this pull request

Image of actuator info endpoint:

![image](https://user-images.githubusercontent.com/76042279/112807374-bc4f1100-906f-11eb-9007-410dd1e797c5.png)


## Guidance to review

- See [docs for including git info in build](https://docs.spring.io/spring-boot/docs/current/reference/html/howto.html#howto-git-info)
- See [docs for exposing git info via the actuator dependency](https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-features.html#production-ready-application-info-git)

