### PR TITLE
Add CORS support to API

### DIFF
--- a/src/main/java/uk/gov/mca/beacons/service/configuration/CorsConfiguration.java
+++ b/src/main/java/uk/gov/mca/beacons/service/configuration/CorsConfiguration.java
@@ -1,0 +1,28 @@
+package uk.gov.mca.beacons.service.configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfiguration {
+
+  @Bean
+  public WebMvcConfigurer corsConfigurer(
+    @Value("${beacons.cors.allowedOrigins}") String[] allowedOrigins
+  ) {
+    return new WebMvcConfigurer() {
+      @Override
+      public void addCorsMappings(CorsRegistry registry) {
+        if (allowedOrigins != null && allowedOrigins.length > 0) {
+          registry
+            .addMapping("/**")
+            .allowedMethods("*")
+            .allowedOrigins(allowedOrigins);
+        }
+      }
+    };
+  }
+}

--- a/src/main/java/uk/gov/mca/beacons/service/registrations/BeaconsController.java
+++ b/src/main/java/uk/gov/mca/beacons/service/registrations/BeaconsController.java
@@ -2,7 +2,6 @@ package uk.gov.mca.beacons.service.registrations;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/uk/gov/mca/beacons/service/registrations/BeaconsController.java
+++ b/src/main/java/uk/gov/mca/beacons/service/registrations/BeaconsController.java
@@ -2,6 +2,7 @@ package uk.gov.mca.beacons.service.registrations;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,3 +19,5 @@ beacons:
   openapi:
     github:
       url: https://github.com/mcagov/beacons-service
+  cors:
+    allowedOrigins: ${BEACONS_CORS_ALLOWED_ORIGINS:*}

--- a/src/test/java/uk/gov/mca/beacons/service/configuration/CorsConfigurationTest.java
+++ b/src/test/java/uk/gov/mca/beacons/service/configuration/CorsConfigurationTest.java
@@ -1,0 +1,69 @@
+package uk.gov.mca.beacons.service.configuration;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.servlet.config.annotation.CorsRegistration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@ExtendWith(MockitoExtension.class)
+class CorsConfigurationTest {
+
+  private CorsConfiguration corsConfiguration;
+
+  private WebMvcConfigurer webMvcConfigurer;
+
+  @Mock
+  private CorsRegistry registry;
+
+  @Mock
+  private CorsRegistration corsRegistration;
+
+  @BeforeEach
+  void init() {
+    corsConfiguration = new CorsConfiguration();
+  }
+
+  @Test
+  void shouldAddTheCorrectCorsConfigurationIfTheAllowedOriginsIsSupplied() {
+    given(registry.addMapping("/**")).willReturn(corsRegistration);
+    given(corsRegistration.allowedMethods("*")).willReturn(corsRegistration);
+    final String[] allowedOrigins = {
+      "http://localhost:8080",
+      "http://localhost:8090",
+    };
+
+    webMvcConfigurer = corsConfiguration.corsConfigurer(allowedOrigins);
+    webMvcConfigurer.addCorsMappings(registry);
+
+    then(corsRegistration).should(times(1)).allowedOrigins(allowedOrigins);
+  }
+
+  @Test
+  void shouldNotCallThroughToTheCorsRegistryIfTheAllowedOriginsIsNull() {
+    webMvcConfigurer = corsConfiguration.corsConfigurer(null);
+    webMvcConfigurer.addCorsMappings(registry);
+    assertMocksNotCalled();
+  }
+
+  @Test
+  void shouldNotCallThroughToTheCorsRegistryIfTheAllowedOriginsIsEmpty() {
+    webMvcConfigurer = corsConfiguration.corsConfigurer(new String[] {});
+    webMvcConfigurer.addCorsMappings(registry);
+    assertMocksNotCalled();
+  }
+
+  private void assertMocksNotCalled() {
+    then(registry).should(never()).addMapping("/**");
+    then(corsRegistration).should(never()).allowedMethods("*");
+    then(corsRegistration).should(never()).allowedOrigins();
+  }
+}

--- a/src/test/java/uk/gov/mca/beacons/service/configuration/CorsConfigurationTest.java
+++ b/src/test/java/uk/gov/mca/beacons/service/configuration/CorsConfigurationTest.java
@@ -43,7 +43,6 @@ class CorsConfigurationTest {
 
     webMvcConfigurer = corsConfiguration.corsConfigurer(allowedOrigins);
     webMvcConfigurer.addCorsMappings(registry);
-
     then(corsRegistration).should(times(1)).allowedOrigins(allowedOrigins);
   }
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -13,3 +13,5 @@ beacons:
   openapi:
     github:
       url: https://github.com/mcagov/beacons-service
+  cors:
+    allowedOrigins: ${BEACONS_CORS_ALLOWED_ORIGINS:*}


### PR DESCRIPTION
## Context

- CORS support is required to allow the back office to make REST requests to the API from a different domain
- This PR adds a global CORS handler exposed by environment variables

## Changes in this pull request

- Adds CORS configuration for the API and exposes environment variables to configure the allowed origins - takes a list of URLs

## Link to Trello card

- https://trello.com/c/rTWbKmqC/528-hook-up-the-back-office-tool-to-the-api

## Things to check

- [ ] Environment variables have been updated
