### PR TITLE
Let the dates be dates

### DIFF
--- a/src/main/java/uk/gov/mca/beacons/service/mappers/BeaconMapper.java
+++ b/src/main/java/uk/gov/mca/beacons/service/mappers/BeaconMapper.java
@@ -63,8 +63,8 @@ public class BeaconMapper {
   }
 
   private static LocalDate getDateOrNull(
-          String key,
-          Map<String, Object> attributes
+    String key,
+    Map<String, Object> attributes
   ) {
     final var attributeValue = (String) attributes.get(key);
     if (attributeValue == null) return null;

--- a/src/main/java/uk/gov/mca/beacons/service/mappers/BeaconMapper.java
+++ b/src/main/java/uk/gov/mca/beacons/service/mappers/BeaconMapper.java
@@ -66,10 +66,15 @@ public class BeaconMapper {
           String key,
           Map<String, Object> attributes
   ) {
-    final var attributeValue = attributes.get(key);
+    final var attributeValue = (String) attributes.get(key);
     if (attributeValue == null) return null;
 
-    return LocalDate.parse((String) attributeValue);
+    return LocalDate.parse(removeTime(attributeValue));
+  }
+
+  private static String removeTime(String dateTimeString) {
+    final var isoDateStringLength = 10; // YYYY-MMM-DD
+    return dateTimeString.substring(0, isoDateStringLength);
   }
 
   private BeaconStatus getStatusOrNull(

--- a/src/main/java/uk/gov/mca/beacons/service/mappers/BeaconMapper.java
+++ b/src/main/java/uk/gov/mca/beacons/service/mappers/BeaconMapper.java
@@ -73,7 +73,7 @@ public class BeaconMapper {
   }
 
   private static String removeTime(String dateTimeString) {
-    final var isoDateStringLength = 10; // YYYY-MMM-DD
+    final var isoDateStringLength = 10; // YYYY-MM-DD
     return dateTimeString.substring(0, isoDateStringLength);
   }
 

--- a/src/main/java/uk/gov/mca/beacons/service/mappers/BeaconMapper.java
+++ b/src/main/java/uk/gov/mca/beacons/service/mappers/BeaconMapper.java
@@ -1,5 +1,6 @@
 package uk.gov.mca.beacons.service.mappers;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Map;
 import org.springframework.stereotype.Service;
@@ -44,22 +45,31 @@ public class BeaconMapper {
 
     beacon.setBeaconStatus(getStatusOrNull("status", attributes));
 
-    beacon.setCreatedDate(getDateOrNull("createdDate", attributes));
+    beacon.setCreatedDate(getDateTimeOrNull("createdDate", attributes));
     beacon.setBatteryExpiryDate(getDateOrNull("batteryExpiryDate", attributes));
     beacon.setLastServicedDate(getDateOrNull("lastServicedDate", attributes));
 
     return beacon;
   }
 
-  private static LocalDateTime getDateOrNull(
+  private static LocalDateTime getDateTimeOrNull(
     String key,
     Map<String, Object> attributes
   ) {
     final var attributeValue = attributes.get(key);
     if (attributeValue == null) return null;
 
-    final var result = LocalDateTime.parse((String) attributeValue);
-    return result;
+    return LocalDateTime.parse((String) attributeValue);
+  }
+
+  private static LocalDate getDateOrNull(
+          String key,
+          Map<String, Object> attributes
+  ) {
+    final var attributeValue = attributes.get(key);
+    if (attributeValue == null) return null;
+
+    return LocalDate.parse((String) attributeValue);
   }
 
   private BeaconStatus getStatusOrNull(
@@ -69,8 +79,6 @@ public class BeaconMapper {
     final var attributeValue = attributes.get(key);
     if (attributeValue == null) return null;
 
-    final var result = BeaconStatus.valueOf((String) attributeValue);
-
-    return result;
+    return BeaconStatus.valueOf((String) attributeValue);
   }
 }

--- a/src/main/java/uk/gov/mca/beacons/service/model/Beacon.java
+++ b/src/main/java/uk/gov/mca/beacons/service/model/Beacon.java
@@ -1,5 +1,6 @@
 package uk.gov.mca.beacons.service.model;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -40,9 +41,9 @@ public class Beacon {
 
   private String chkCode;
 
-  private LocalDateTime batteryExpiryDate;
+  private LocalDate batteryExpiryDate;
 
-  private LocalDateTime lastServicedDate;
+  private LocalDate lastServicedDate;
 
   @Enumerated(EnumType.STRING)
   private BeaconStatus beaconStatus;
@@ -120,19 +121,19 @@ public class Beacon {
     this.chkCode = chkCode;
   }
 
-  public LocalDateTime getBatteryExpiryDate() {
+  public LocalDate getBatteryExpiryDate() {
     return batteryExpiryDate;
   }
 
-  public void setBatteryExpiryDate(LocalDateTime batteryExpiryDate) {
+  public void setBatteryExpiryDate(LocalDate batteryExpiryDate) {
     this.batteryExpiryDate = batteryExpiryDate;
   }
 
-  public LocalDateTime getLastServicedDate() {
+  public LocalDate getLastServicedDate() {
     return lastServicedDate;
   }
 
-  public void setLastServicedDate(LocalDateTime lastServicedDate) {
+  public void setLastServicedDate(LocalDate lastServicedDate) {
     this.lastServicedDate = lastServicedDate;
   }
 

--- a/src/main/resources/db/migration/V1.9__Timestamp_To_Date_Types.sql
+++ b/src/main/resources/db/migration/V1.9__Timestamp_To_Date_Types.sql
@@ -1,0 +1,7 @@
+-- Change TIMESTAMP types on battery_expiry and last_serviced to LOCALDATE
+-- The underlying data is a date type; this migration removes time information, resulting in greater accuracy and
+-- avoids off-by-one errors where the time is incorrectly interpreted
+
+ALTER TABLE beacon
+    ALTER COLUMN battery_expiry_date TYPE date,
+    ALTER COLUMN last_serviced_date TYPE date;

--- a/src/test/java/uk/gov/mca/beacons/service/beacons/BeaconsControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/mca/beacons/service/beacons/BeaconsControllerIntegrationTest.java
@@ -1,5 +1,6 @@
 package uk.gov.mca.beacons.service.beacons;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -44,8 +45,8 @@ class BeaconsControllerIntegrationTest {
     beacon.setManufacturerSerialNumber("1407312904");
     beacon.setChkCode("9480B");
     beacon.setHexId("HEXID123");
-    beacon.setBatteryExpiryDate(LocalDateTime.of(2020, 2, 1, 0, 0));
-    beacon.setLastServicedDate(LocalDateTime.of(2020, 2, 1, 0, 0));
+    beacon.setBatteryExpiryDate(LocalDate.of(2020, 2, 1));
+    beacon.setLastServicedDate(LocalDate.of(2020, 2, 1));
     final var owner = new BeaconPerson();
     owner.setAddressLine1("2 The Hard");
     owner.setAddressLine2("");

--- a/src/test/java/uk/gov/mca/beacons/service/beacons/BeaconsServicePatchIntegrationTest.java
+++ b/src/test/java/uk/gov/mca/beacons/service/beacons/BeaconsServicePatchIntegrationTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Optional;
@@ -60,12 +61,12 @@ class BeaconsServicePatchIntegrationTest {
       .willReturn(Collections.emptyList());
 
     var updateBeacon = new Beacon();
-    updateBeacon.setBatteryExpiryDate(LocalDateTime.of(2001, 01, 02, 03, 04));
+    updateBeacon.setBatteryExpiryDate(LocalDate.of(2001, 1, 2));
     updateBeacon.setBeaconStatus(BeaconStatus.NEW);
     updateBeacon.setChkCode("a-chk-code");
     updateBeacon.setCreatedDate(LocalDateTime.of(2002, 11, 12, 13, 14));
     updateBeacon.setHexId("HEXID");
-    updateBeacon.setLastServicedDate(LocalDateTime.of(1983, 03, 13, 03, 04));
+    updateBeacon.setLastServicedDate(LocalDate.of(1983, 3, 13));
     updateBeacon.setManufacturer("Beacons-R-Us");
     updateBeacon.setManufacturerSerialNumber("mambonbr5");
     updateBeacon.setModel("Naomi");
@@ -77,7 +78,7 @@ class BeaconsServicePatchIntegrationTest {
     verify(mockBeaconRepo).save(beaconCapture.capture());
     assertThat(
       beaconCapture.getValue().getBatteryExpiryDate(),
-      is(LocalDateTime.of(2001, 01, 02, 03, 04))
+      is(LocalDate.of(2001, 1, 2))
     );
     assertThat(
       beaconCapture.getValue().getBeaconStatus(),
@@ -91,7 +92,7 @@ class BeaconsServicePatchIntegrationTest {
     assertThat(beaconCapture.getValue().getHexId(), is("HEXID"));
     assertThat(
       beaconCapture.getValue().getLastServicedDate(),
-      is(LocalDateTime.of(1983, 03, 13, 03, 04))
+      is(LocalDate.of(1983, 3, 13))
     );
     assertThat(beaconCapture.getValue().getManufacturer(), is("Beacons-R-Us"));
     assertThat(
@@ -113,7 +114,7 @@ class BeaconsServicePatchIntegrationTest {
     oldBeacon.setManufacturerSerialNumber("mambonbr5");
     oldBeacon.setReferenceNumber("a-ref-num");
 
-    oldBeacon.setLastServicedDate(LocalDateTime.of(1992, 11, 8, 03, 04));
+    oldBeacon.setLastServicedDate(LocalDate.of(1992, 11, 8));
     oldBeacon.setManufacturer("Beacon-4-U");
     oldBeacon.setModel("Naomi");
 
@@ -124,10 +125,10 @@ class BeaconsServicePatchIntegrationTest {
       .willReturn(Collections.emptyList());
 
     var updateBeacon = new Beacon();
-    updateBeacon.setBatteryExpiryDate(LocalDateTime.of(2001, 01, 02, 03, 04));
+    updateBeacon.setBatteryExpiryDate(LocalDate.of(2001, 1, 2));
     updateBeacon.setBeaconStatus(BeaconStatus.NEW);
     updateBeacon.setHexId("HEXID");
-    updateBeacon.setLastServicedDate(LocalDateTime.of(1983, 03, 13, 03, 04));
+    updateBeacon.setLastServicedDate(LocalDate.of(1983, 3, 13));
     updateBeacon.setManufacturer("Beacons-R-Us");
     updateBeacon.setModel("ASOS");
 
@@ -137,7 +138,7 @@ class BeaconsServicePatchIntegrationTest {
     verify(mockBeaconRepo).save(beaconCapture.capture());
     assertThat(
       beaconCapture.getValue().getBatteryExpiryDate(),
-      is(LocalDateTime.of(2001, 01, 02, 03, 04))
+      is(LocalDate.of(2001, 1, 2))
     );
     assertThat(
       beaconCapture.getValue().getBeaconStatus(),
@@ -151,7 +152,7 @@ class BeaconsServicePatchIntegrationTest {
     assertThat(beaconCapture.getValue().getHexId(), is("HEXID"));
     assertThat(
       beaconCapture.getValue().getLastServicedDate(),
-      is(LocalDateTime.of(1983, 03, 13, 03, 04))
+      is(LocalDate.of(1983, 3, 13))
     );
     assertThat(beaconCapture.getValue().getManufacturer(), is("Beacons-R-Us"));
     assertThat(

--- a/src/test/java/uk/gov/mca/beacons/service/mappers/BeaconMapperUnitTest.java
+++ b/src/test/java/uk/gov/mca/beacons/service/mappers/BeaconMapperUnitTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.DateTimeException;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,8 +38,8 @@ class BeaconMapperUnitTest {
     beaconDTO.addAttribute("manufacturerSerialNumber", "3");
     beaconDTO.addAttribute("status", "NEW");
     beaconDTO.addAttribute("createdDate", "2020-02-01T00:00");
-    beaconDTO.addAttribute("batteryExpiryDate", "2022-02-01T00:00");
-    beaconDTO.addAttribute("lastServicedDate", "2019-02-01T00:00");
+    beaconDTO.addAttribute("batteryExpiryDate", "2022-02-01");
+    beaconDTO.addAttribute("lastServicedDate", "2019-02-01");
 
     var beacon = beaconMapper.fromDTO(beaconDTO);
 
@@ -55,11 +56,11 @@ class BeaconMapperUnitTest {
     );
     assertThat(
       beacon.getBatteryExpiryDate(),
-      is(LocalDateTime.of(2022, 2, 1, 0, 0, 0))
+      is(LocalDate.of(2022, 2, 1))
     );
     assertThat(
       beacon.getLastServicedDate(),
-      is(LocalDateTime.of(2019, 2, 1, 0, 0, 0))
+      is(LocalDate.of(2019, 2, 1))
     );
   }
 
@@ -82,9 +83,7 @@ class BeaconMapperUnitTest {
     beaconDTO.addAttribute("status", "RETIRED");
     assertThrows(
       IllegalArgumentException.class,
-      () -> {
-        beaconMapper.fromDTO(beaconDTO);
-      }
+      () -> beaconMapper.fromDTO(beaconDTO)
     );
   }
 
@@ -95,9 +94,7 @@ class BeaconMapperUnitTest {
 
     assertThrows(
       DateTimeException.class,
-      () -> {
-        beaconMapper.fromDTO(beaconDTO);
-      }
+      () -> beaconMapper.fromDTO(beaconDTO)
     );
   }
 }

--- a/src/test/java/uk/gov/mca/beacons/service/mappers/BeaconMapperUnitTest.java
+++ b/src/test/java/uk/gov/mca/beacons/service/mappers/BeaconMapperUnitTest.java
@@ -54,14 +54,8 @@ class BeaconMapperUnitTest {
       beacon.getCreatedDate(),
       is(LocalDateTime.of(2020, 2, 1, 0, 0, 0))
     );
-    assertThat(
-      beacon.getBatteryExpiryDate(),
-      is(LocalDate.of(2022, 2, 1))
-    );
-    assertThat(
-      beacon.getLastServicedDate(),
-      is(LocalDate.of(2019, 2, 1))
-    );
+    assertThat(beacon.getBatteryExpiryDate(), is(LocalDate.of(2022, 2, 1)));
+    assertThat(beacon.getLastServicedDate(), is(LocalDate.of(2019, 2, 1)));
   }
 
   @Test
@@ -105,13 +99,7 @@ class BeaconMapperUnitTest {
 
     var beacon = beaconMapper.fromDTO(beaconDTO);
 
-    assertThat(
-            beacon.getBatteryExpiryDate(),
-            is(LocalDate.of(2022, 2, 1))
-    );
-    assertThat(
-            beacon.getLastServicedDate(),
-            is(LocalDate.of(2019, 2, 1))
-    );
+    assertThat(beacon.getBatteryExpiryDate(), is(LocalDate.of(2022, 2, 1)));
+    assertThat(beacon.getLastServicedDate(), is(LocalDate.of(2019, 2, 1)));
   }
 }

--- a/src/test/java/uk/gov/mca/beacons/service/mappers/BeaconMapperUnitTest.java
+++ b/src/test/java/uk/gov/mca/beacons/service/mappers/BeaconMapperUnitTest.java
@@ -97,4 +97,21 @@ class BeaconMapperUnitTest {
       () -> beaconMapper.fromDTO(beaconDTO)
     );
   }
+
+  @Test
+  void shouldAccuratelyStripTimeInformationFromDateFields() {
+    beaconDTO.addAttribute("batteryExpiryDate", "2022-02-01T00:00");
+    beaconDTO.addAttribute("lastServicedDate", "2019-02-01T00:00");
+
+    var beacon = beaconMapper.fromDTO(beaconDTO);
+
+    assertThat(
+            beacon.getBatteryExpiryDate(),
+            is(LocalDate.of(2022, 2, 1))
+    );
+    assertThat(
+            beacon.getLastServicedDate(),
+            is(LocalDate.of(2019, 2, 1))
+    );
+  }
 }

--- a/src/test/java/uk/gov/mca/beacons/service/serializer/BeaconsSearchResultSerializerTest.java
+++ b/src/test/java/uk/gov/mca/beacons/service/serializer/BeaconsSearchResultSerializerTest.java
@@ -13,6 +13,7 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -44,7 +45,7 @@ class BeaconsSearchResultSerializerTest {
     beaconsSearchResult = new BeaconsSearchResult();
 
     beaconsSearchResult.setBeacons(List.of());
-    jsonWriter = (Writer) new StringWriter();
+    jsonWriter = new StringWriter();
     jsonGenerator = new JsonFactory().createGenerator(jsonWriter);
     serializerProvider = new ObjectMapper().getSerializerProvider();
   }
@@ -82,8 +83,8 @@ class BeaconsSearchResultSerializerTest {
     beacon.setModel("EPIRB1");
     beacon.setManufacturerSerialNumber("1407312904");
     beacon.setChkCode("9480B");
-    beacon.setBatteryExpiryDate(LocalDateTime.of(2020, 2, 1, 0, 0));
-    beacon.setLastServicedDate(LocalDateTime.of(2020, 2, 1, 0, 0));
+    beacon.setBatteryExpiryDate(LocalDate.of(2020, 2, 1));
+    beacon.setLastServicedDate(LocalDate.of(2020, 2, 1));
     final var owner = new BeaconPerson();
     owner.setAddressLine1("1 The Hard");
     owner.setAddressLine2("");

--- a/src/test/resources/fixtures/beaconSearch.json
+++ b/src/test/resources/fixtures/beaconSearch.json
@@ -15,8 +15,8 @@
         "model": "EPIRB1",
         "manufacturerSerialNumber": "1407312904",
         "chkCode": "9480B",
-        "batteryExpiryDate": "2020-02-01T00:00",
-        "lastServicedDate": "2020-02-01T00:00",
+        "batteryExpiryDate": "2020-02-01",
+        "lastServicedDate": "2020-02-01",
         "uses": [
           {
             "environment": "MARITIME",

--- a/src/test/resources/fixtures/getBeaconResponse.json
+++ b/src/test/resources/fixtures/getBeaconResponse.json
@@ -14,8 +14,8 @@
       "model": "EPIRB1",
       "manufacturerSerialNumber": "1407312904",
       "chkCode": "9480B",
-      "batteryExpiryDate": "2020-02-01T00:00",
-      "lastServicedDate": "2020-02-01T00:00"
+      "batteryExpiryDate": "2020-02-01",
+      "lastServicedDate": "2020-02-01"
     },
     "relationships": {
       "uses": {

--- a/src/test/resources/fixtures/registrations.json
+++ b/src/test/resources/fixtures/registrations.json
@@ -8,8 +8,8 @@
         "manufacturerSerialNumber": "1407312904",
         "chkCode": "9480B",
         "referenceNumber": "ABCDE4",
-        "batteryExpiryDate": "2020-02-01T00:00:00.000Z",
-        "lastServicedDate": "2020-02-01T00:00:00.000Z",
+        "batteryExpiryDate": "2020-02-01",
+        "lastServicedDate": "2020-02-01",
         "uses": [
           {
             "environment": "MARITIME",
@@ -138,8 +138,8 @@
         "model": "S20 Lifejacket AIS Beacon",
         "manufacturerSerialNumber": "1407312904",
         "chkCode": "9480B",
-        "batteryExpiryDate": "2020-02-01T00:00:00.000Z",
-        "lastServicedDate": "2020-02-01T00:00:00.000Z",
+        "batteryExpiryDate": "2020-02-01",
+        "lastServicedDate": "2020-02-01",
         "uses": [
           {
             "environment": "MARITIME",
@@ -189,8 +189,8 @@
         "model": "EPIRB1",
         "manufacturerSerialNumber": "1407312904",
         "chkCode": "9480B",
-        "batteryExpiryDate": "2020-02-01T00:00:00.000Z",
-        "lastServicedDate": "2020-02-01T00:00:00.000Z",
+        "batteryExpiryDate": "2020-02-01",
+        "lastServicedDate": "2020-02-01",
         "uses": [
           {
             "environment": "MARITIME",
@@ -235,8 +235,8 @@
         "model": "EPIRB1",
         "manufacturerSerialNumber": "1407312904",
         "chkCode": "9480B",
-        "batteryExpiryDate": "2020-02-01T00:00:00.000Z",
-        "lastServicedDate": "2020-02-01T00:00:00.000Z",
+        "batteryExpiryDate": "2020-02-01",
+        "lastServicedDate": "2020-02-01",
         "uses": [],
         "owner": {
           "fullName": "Vice-Admiral Horatio Nelson, 1st Viscount Nelson",


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

We [decided](https://madetechteam.slack.com/archives/G01QCKT0E3E/p1621239245004500?thread_ts=1620999207.043000&cid=G01QCKT0E3E) to persist the domain concepts of a Beacon's `batteryExpiryDate` and `lastServicedDate` using the Postgres type `DATE` instead of `DATETIME`.  

- A more accurate data model (the _time_ a battery expires or when the Beacon was last serviced does not exist or is not significant in the domain).
- Greater predictability across different systems and locales, e.g. user's browser -> webapp backend -> API -> backoffice tool.  The scope for off-by-one errors and other time/timezone snafus is reduced by just using dates.

`TIMESTAMP` fields where time is relevant (`createdAt`, `lastModified`) are left as-is.

## Changes in this pull request

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->

- DB migration
- Necessary updates to tests, fixtures and application code to handle `LocalDate` where it was previously `LocalDateTime`.
- Add a bit of defensive code to `BeaconMapper` to handle situations where something more than just `YYYY-MM-DD` is POST'd (e.g. `2020-04-20T00:00`).  We may not need this, but I thought it prudent / good practice at least for the period between merging this PR and updating the frontend to use the new version of the API.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

How will this affect beacon data in staging and production?  I think Postgres will just strip time data from the existing `timestamp` fields?