### PR TITLE
Test that Registrations can be POSTed for existing account holders

### DIFF
--- a/src/test/java/uk/gov/mca/beacons/api/controllers/RegistrationsControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/controllers/RegistrationsControllerIntegrationTest.java
@@ -23,99 +23,113 @@ import uk.gov.mca.beacons.api.services.CreateAccountHolderService;
 @AutoConfigureWebTestClient
 class RegistrationsControllerIntegrationTest {
 
-    private static final String REGISTRATION_ENDPOINT = "/registrations/register";
-    private static final String REGISTRATION_JSON_RESOURCE =
-            "src/test/resources/fixtures/registrations.json";
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final String REGISTRATION_ENDPOINT = "/registrations/register";
+  private static final String REGISTRATION_JSON_RESOURCE =
+    "src/test/resources/fixtures/registrations.json";
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-    @Autowired
-    private WebTestClient webTestClient;
+  @Autowired
+  private WebTestClient webTestClient;
 
-    @Autowired
-    private CreateAccountHolderService createAccountHolderService;
+  @Autowired
+  private CreateAccountHolderService createAccountHolderService;
 
-    @ParameterizedTest
-    @EnumSource(
-            value = RegistrationUseCase.class,
-            names = {"SINGLE_BEACON", "MULTIPLE_BEACONS"}
+  @ParameterizedTest
+  @EnumSource(
+    value = RegistrationUseCase.class,
+    names = { "SINGLE_BEACON", "MULTIPLE_BEACONS" }
+  )
+  void givenNewValidRegistration_whenPosted_thenStatus201(
+    RegistrationUseCase registrationUseCase
+  ) throws IOException {
+    UUID testAccountHolderId = createTestAccountHolder();
+    var requestBody = toJson(
+      readFile(REGISTRATION_JSON_RESOURCE)
+        .replace(
+          "replace-with-test-account-holder-id",
+          testAccountHolderId.toString()
+        )
     )
-    void givenNewValidRegistration_whenPosted_thenStatus201(
-            RegistrationUseCase registrationUseCase
-    ) throws IOException {
-        UUID testAccountHolderId = createTestAccountHolder();
-        var requestBody = toJson(readFile(REGISTRATION_JSON_RESOURCE)
-                .replace("replace-with-test-account-holder-id", testAccountHolderId.toString()))
-                .get(registrationUseCase);
+      .get(registrationUseCase);
 
-        makePostRequest(requestBody)
-                .expectStatus()
-                .isCreated()
-                .expectHeader()
-                .valueEquals("Content-Type", MediaType.APPLICATION_JSON_VALUE);
-    }
+    makePostRequest(requestBody)
+      .expectStatus()
+      .isCreated()
+      .expectHeader()
+      .valueEquals("Content-Type", MediaType.APPLICATION_JSON_VALUE);
+  }
 
-    @ParameterizedTest
-    @EnumSource(
-            value = RegistrationUseCase.class,
-            names = {"NO_HEX_ID", "NO_USES", "NO_EMERGENCY_CONTACTS"}
+  @ParameterizedTest
+  @EnumSource(
+    value = RegistrationUseCase.class,
+    names = { "NO_HEX_ID", "NO_USES", "NO_EMERGENCY_CONTACTS" }
+  )
+  void givenInvalidRegistration_whenPosted_thenStatus400(
+    RegistrationUseCase registrationUseCase
+  ) throws IOException {
+    UUID testAccountHolderId = createTestAccountHolder();
+    var requestBody = toJson(
+      readFile(REGISTRATION_JSON_RESOURCE)
+        .replace(
+          "replace-with-test-account-holder-id",
+          testAccountHolderId.toString()
+        )
     )
-    void givenInvalidRegistration_whenPosted_thenStatus400(
-            RegistrationUseCase registrationUseCase
-    ) throws IOException {
-        UUID testAccountHolderId = createTestAccountHolder();
-        var requestBody = toJson(readFile(REGISTRATION_JSON_RESOURCE)
-                .replace("replace-with-test-account-holder-id", testAccountHolderId.toString()))
-                .get(registrationUseCase);
+      .get(registrationUseCase);
 
-        makePostRequest(requestBody)
-                .expectStatus()
-                .isBadRequest()
-                .expectHeader()
-                .valueEquals("Content-Type", MediaType.APPLICATION_JSON_VALUE);
-    }
+    makePostRequest(requestBody)
+      .expectStatus()
+      .isBadRequest()
+      .expectHeader()
+      .valueEquals("Content-Type", MediaType.APPLICATION_JSON_VALUE);
+  }
 
-    private WebTestClient.ResponseSpec makePostRequest(Object json) {
-        return webTestClient
-                .post()
-                .uri(REGISTRATION_ENDPOINT)
-                .contentType(MediaType.APPLICATION_JSON)
-                .bodyValue(json)
-                .exchange();
-    }
+  private WebTestClient.ResponseSpec makePostRequest(Object json) {
+    return webTestClient
+      .post()
+      .uri(REGISTRATION_ENDPOINT)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(json)
+      .exchange();
+  }
 
-    private Map<RegistrationUseCase, Object> toJson(String registrationFixture) throws JsonProcessingException {
-        final TypeReference<EnumMap<RegistrationUseCase, Object>> typeReference = new TypeReference<>() {
-        };
-        return OBJECT_MAPPER.readValue(registrationFixture, typeReference);
-    }
+  private Map<RegistrationUseCase, Object> toJson(String registrationFixture)
+    throws JsonProcessingException {
+    final TypeReference<EnumMap<RegistrationUseCase, Object>> typeReference = new TypeReference<>() {};
+    return OBJECT_MAPPER.readValue(registrationFixture, typeReference);
+  }
 
-    private UUID createTestAccountHolder() {
-        CreateAccountHolderRequest createAccountHolderRequest = CreateAccountHolderRequest.builder()
-                .authId(UUID.randomUUID().toString())
-                .email("testy@mctestface.com")
-                .fullName("Tesy McTestface")
-                .telephoneNumber("01178 657123")
-                .alternativeTelephoneNumber("01178 657124")
-                .addressLine1("Flat 42")
-                .addressLine2("Testington Towers")
-                .addressLine3("Tower Test")
-                .addressLine4("Testing Towers")
-                .townOrCity("Testville")
-                .postcode("TS1 23A")
-                .county("Testershire").build();
+  private UUID createTestAccountHolder() {
+    CreateAccountHolderRequest createAccountHolderRequest = CreateAccountHolderRequest
+      .builder()
+      .authId(UUID.randomUUID().toString())
+      .email("testy@mctestface.com")
+      .fullName("Tesy McTestface")
+      .telephoneNumber("01178 657123")
+      .alternativeTelephoneNumber("01178 657124")
+      .addressLine1("Flat 42")
+      .addressLine2("Testington Towers")
+      .addressLine3("Tower Test")
+      .addressLine4("Testing Towers")
+      .townOrCity("Testville")
+      .postcode("TS1 23A")
+      .county("Testershire")
+      .build();
 
-        return createAccountHolderService.execute(createAccountHolderRequest).getId();
-    }
+    return createAccountHolderService
+      .execute(createAccountHolderRequest)
+      .getId();
+  }
 
-    private String readFile(String filePath) throws IOException {
-        return new String(Files.readAllBytes(Paths.get(filePath)));
-    }
+  private String readFile(String filePath) throws IOException {
+    return new String(Files.readAllBytes(Paths.get(filePath)));
+  }
 
-    enum RegistrationUseCase {
-        SINGLE_BEACON,
-        MULTIPLE_BEACONS,
-        NO_HEX_ID,
-        NO_USES,
-        NO_EMERGENCY_CONTACTS,
-    }
+  enum RegistrationUseCase {
+    SINGLE_BEACON,
+    MULTIPLE_BEACONS,
+    NO_HEX_ID,
+    NO_USES,
+    NO_EMERGENCY_CONTACTS,
+  }
 }

--- a/src/test/java/uk/gov/mca/beacons/api/controllers/RegistrationsControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/controllers/RegistrationsControllerIntegrationTest.java
@@ -1,5 +1,6 @@
 package uk.gov.mca.beacons.api.controllers;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
@@ -7,6 +8,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.UUID;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,76 +16,106 @@ import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWeb
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import uk.gov.mca.beacons.api.dto.CreateAccountHolderRequest;
+import uk.gov.mca.beacons.api.services.CreateAccountHolderService;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureWebTestClient
 class RegistrationsControllerIntegrationTest {
 
-  private static final String REGISTRATION_ENDPOINT = "/registrations/register";
-  private static final String REGISTRATION_JSON_RESOURCE =
-    "src/test/resources/fixtures/registrations.json";
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String REGISTRATION_ENDPOINT = "/registrations/register";
+    private static final String REGISTRATION_JSON_RESOURCE =
+            "src/test/resources/fixtures/registrations.json";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-  @Autowired
-  private WebTestClient webTestClient;
+    @Autowired
+    private WebTestClient webTestClient;
 
-  @ParameterizedTest
-  @EnumSource(
-    value = RegistrationUseCase.class,
-    names = { "SINGLE_BEACON", "MULTIPLE_BEACONS" }
-  )
-  void givenNewValidRegistration_whenPosted_thenStatus201(
-    RegistrationUseCase registrationJson
-  ) throws IOException {
-    final Map<RegistrationUseCase, Object> registrationsJson = getRegistrationsJson();
+    @Autowired
+    private CreateAccountHolderService createAccountHolderService;
 
-    makePostRequest(registrationsJson.get(registrationJson))
-      .expectStatus()
-      .isCreated()
-      .expectHeader()
-      .valueEquals("Content-Type", MediaType.APPLICATION_JSON_VALUE);
-  }
+    @ParameterizedTest
+    @EnumSource(
+            value = RegistrationUseCase.class,
+            names = {"SINGLE_BEACON", "MULTIPLE_BEACONS"}
+    )
+    void givenNewValidRegistration_whenPosted_thenStatus201(
+            RegistrationUseCase registrationUseCase
+    ) throws IOException {
+        UUID testAccountHolderId = createTestAccountHolder();
+        var requestBody = toJson(readFile(REGISTRATION_JSON_RESOURCE)
+                .replace("replace-with-test-account-holder-id", testAccountHolderId.toString()))
+                .get(registrationUseCase);
 
-  @ParameterizedTest
-  @EnumSource(
-    value = RegistrationUseCase.class,
-    names = { "NO_HEX_ID", "NO_USES", "NO_EMERGENCY_CONTACTS" }
-  )
-  void givenInvalidRegistration_whenPosted_thenStatus400(
-    RegistrationUseCase registrationJson
-  ) throws IOException {
-    final Map<RegistrationUseCase, Object> registrationsJson = getRegistrationsJson();
+        makePostRequest(requestBody)
+                .expectStatus()
+                .isCreated()
+                .expectHeader()
+                .valueEquals("Content-Type", MediaType.APPLICATION_JSON_VALUE);
+    }
 
-    makePostRequest(registrationsJson.get(registrationJson))
-      .expectStatus()
-      .isBadRequest()
-      .expectHeader()
-      .valueEquals("Content-Type", MediaType.APPLICATION_JSON_VALUE);
-  }
+    @ParameterizedTest
+    @EnumSource(
+            value = RegistrationUseCase.class,
+            names = {"NO_HEX_ID", "NO_USES", "NO_EMERGENCY_CONTACTS"}
+    )
+    void givenInvalidRegistration_whenPosted_thenStatus400(
+            RegistrationUseCase registrationUseCase
+    ) throws IOException {
+        UUID testAccountHolderId = createTestAccountHolder();
+        var requestBody = toJson(readFile(REGISTRATION_JSON_RESOURCE)
+                .replace("replace-with-test-account-holder-id", testAccountHolderId.toString()))
+                .get(registrationUseCase);
 
-  private WebTestClient.ResponseSpec makePostRequest(Object json) {
-    return webTestClient
-      .post()
-      .uri(REGISTRATION_ENDPOINT)
-      .contentType(MediaType.APPLICATION_JSON)
-      .bodyValue(json)
-      .exchange();
-  }
+        makePostRequest(requestBody)
+                .expectStatus()
+                .isBadRequest()
+                .expectHeader()
+                .valueEquals("Content-Type", MediaType.APPLICATION_JSON_VALUE);
+    }
 
-  private Map<RegistrationUseCase, Object> getRegistrationsJson()
-    throws IOException {
-    final String json = new String(
-      Files.readAllBytes(Paths.get(REGISTRATION_JSON_RESOURCE))
-    );
-    final TypeReference<EnumMap<RegistrationUseCase, Object>> typeReference = new TypeReference<>() {};
-    return OBJECT_MAPPER.readValue(json, typeReference);
-  }
+    private WebTestClient.ResponseSpec makePostRequest(Object json) {
+        return webTestClient
+                .post()
+                .uri(REGISTRATION_ENDPOINT)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(json)
+                .exchange();
+    }
 
-  enum RegistrationUseCase {
-    SINGLE_BEACON,
-    MULTIPLE_BEACONS,
-    NO_HEX_ID,
-    NO_USES,
-    NO_EMERGENCY_CONTACTS,
-  }
+    private Map<RegistrationUseCase, Object> toJson(String registrationFixture) throws JsonProcessingException {
+        final TypeReference<EnumMap<RegistrationUseCase, Object>> typeReference = new TypeReference<>() {
+        };
+        return OBJECT_MAPPER.readValue(registrationFixture, typeReference);
+    }
+
+    private UUID createTestAccountHolder() {
+        CreateAccountHolderRequest createAccountHolderRequest = CreateAccountHolderRequest.builder()
+                .authId(UUID.randomUUID().toString())
+                .email("testy@mctestface.com")
+                .fullName("Tesy McTestface")
+                .telephoneNumber("01178 657123")
+                .alternativeTelephoneNumber("01178 657124")
+                .addressLine1("Flat 42")
+                .addressLine2("Testington Towers")
+                .addressLine3("Tower Test")
+                .addressLine4("Testing Towers")
+                .townOrCity("Testville")
+                .postcode("TS1 23A")
+                .county("Testershire").build();
+
+        return createAccountHolderService.execute(createAccountHolderRequest).getId();
+    }
+
+    private String readFile(String filePath) throws IOException {
+        return new String(Files.readAllBytes(Paths.get(filePath)));
+    }
+
+    enum RegistrationUseCase {
+        SINGLE_BEACON,
+        MULTIPLE_BEACONS,
+        NO_HEX_ID,
+        NO_USES,
+        NO_EMERGENCY_CONTACTS,
+    }
 }

--- a/src/test/java/uk/gov/mca/beacons/api/controllers/RegistrationsControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/controllers/RegistrationsControllerIntegrationTest.java
@@ -42,8 +42,8 @@ class RegistrationsControllerIntegrationTest {
   void givenNewValidRegistration_whenPosted_thenStatus201(
     RegistrationUseCase registrationUseCase
   ) throws IOException {
-    UUID testAccountHolderId = createTestAccountHolder();
-    var requestBody = toJson(
+    final UUID testAccountHolderId = createTestAccountHolder();
+    final Object requestBody = toJson(
       readFile(REGISTRATION_JSON_RESOURCE)
         .replace(
           "replace-with-test-account-holder-id",
@@ -67,8 +67,8 @@ class RegistrationsControllerIntegrationTest {
   void givenInvalidRegistration_whenPosted_thenStatus400(
     RegistrationUseCase registrationUseCase
   ) throws IOException {
-    UUID testAccountHolderId = createTestAccountHolder();
-    var requestBody = toJson(
+    final UUID testAccountHolderId = createTestAccountHolder();
+    final Object requestBody = toJson(
       readFile(REGISTRATION_JSON_RESOURCE)
         .replace(
           "replace-with-test-account-holder-id",

--- a/src/test/resources/fixtures/registrations.json
+++ b/src/test/resources/fixtures/registrations.json
@@ -2,6 +2,7 @@
   "SINGLE_BEACON": {
     "beacons": [
       {
+        "accountHolderId": "replace-with-test-account-holder-id",
         "hexId": "1D0EA08C52FFBFF",
         "manufacturer": "Ocean Signal",
         "model": "EPIRB1",
@@ -85,6 +86,7 @@
   "MULTIPLE_BEACONS": {
     "beacons": [
       {
+        "accountHolderId": "replace-with-test-account-holder-id",
         "hexId": "1D0EA08C52FFBFF",
         "manufacturer": "Ocean Signal",
         "model": "EPIRB1",
@@ -189,6 +191,7 @@
   "NO_HEX_ID": {
     "beacons": [
       {
+        "accountHolderId": "replace-with-test-account-holder-id",
         "manufacturer": "Ocean Signal",
         "model": "EPIRB1",
         "manufacturerSerialNumber": "1407312904",
@@ -235,6 +238,7 @@
   "NO_USES": {
     "beacons": [
       {
+        "accountHolderId": "replace-with-test-account-holder-id",
         "hexId": "1D0EA08C52FFBFF",
         "manufacturer": "Ocean Signal",
         "model": "EPIRB1",
@@ -271,6 +275,7 @@
   "NO_EMERGENCY_CONTACTS": {
     "beacons": [
       {
+        "accountHolderId": "replace-with-test-account-holder-id",
         "hexId": "1D0EA08C52FFBFF",
         "manufacturer": "Ocean Signal",
         "model": "EPIRB1",


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

Updates the Registrations Controller integration tests + fixtures to handle cases where a new registration is created for an existing account holder.

This sets the scene for creating test cases where no account holder exists.

## Changes in this pull request

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->

- Update Registrations fixtures to include an account holder field.
- Helper method in the tests to create a test account holder in the arrange step.
- Small re-jigging of how fixtures are imported so that dynamic data (`"replace-with-test-account-holder-id"`) can be injected into the fixture.  (Pattern first used in `AccountHolderControllerIntegrationTest`).

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/N98xJRu7

## Things to check

- ~~[ ] Environment variables have been updated~~ N/A
