### PR TITLE
Migrated column for beacon person

### DIFF
--- a/src/main/java/uk/gov/mca/beacons/api/dto/BeaconPersonDTO.java
+++ b/src/main/java/uk/gov/mca/beacons/api/dto/BeaconPersonDTO.java
@@ -60,5 +60,6 @@ public class BeaconPersonDTO extends DomainDTO<Attributes> {
     private Integer createUserId;
     private Integer updateUserId;
     private Integer versioning;
+    private Boolean migrated;
   }
 }

--- a/src/main/java/uk/gov/mca/beacons/api/dto/CreateOwnerRequest.java
+++ b/src/main/java/uk/gov/mca/beacons/api/dto/CreateOwnerRequest.java
@@ -35,4 +35,5 @@ public class CreateOwnerRequest {
   private Integer createUserId;
   private Integer updateUserId;
   private Integer versioning;
+  private Boolean migrated;
 }

--- a/src/main/java/uk/gov/mca/beacons/api/jpa/entities/Person.java
+++ b/src/main/java/uk/gov/mca/beacons/api/jpa/entities/Person.java
@@ -79,4 +79,6 @@ public class Person {
   private Integer updateUserId;
 
   private Integer versioning;
+
+  private Boolean migrated;
 }

--- a/src/main/java/uk/gov/mca/beacons/api/mappers/BeaconPersonMapper.java
+++ b/src/main/java/uk/gov/mca/beacons/api/mappers/BeaconPersonMapper.java
@@ -39,6 +39,7 @@ public class BeaconPersonMapper {
       .createUserId(domain.getCreateUserId())
       .updateUserId(domain.getUpdateUserId())
       .versioning(domain.getVersioning())
+      .migrated(domain.getMigrated())
       .build();
     dto.setAttributes(attributes);
 
@@ -76,6 +77,7 @@ public class BeaconPersonMapper {
     beaconPerson.setCreateUserId(attributes.getCreateUserId());
     beaconPerson.setUpdateUserId(attributes.getUpdateUserId());
     beaconPerson.setVersioning(attributes.getVersioning());
+    beaconPerson.setMigrated(attributes.getMigrated());
 
     return beaconPerson;
   }

--- a/src/main/java/uk/gov/mca/beacons/api/mappers/CreateOwnerRequestMapper.java
+++ b/src/main/java/uk/gov/mca/beacons/api/mappers/CreateOwnerRequestMapper.java
@@ -46,6 +46,7 @@ public class CreateOwnerRequestMapper {
     owner.setCreateUserId(request.getCreateUserId());
     owner.setUpdateUserId(request.getUpdateUserId());
     owner.setVersioning(request.getVersioning());
+    owner.setMigrated(request.getMigrated());
 
     return owner;
   }
@@ -80,6 +81,7 @@ public class CreateOwnerRequestMapper {
       .createUserId(owner.getCreateUserId())
       .updateUserId(owner.getUpdateUserId())
       .versioning(owner.getVersioning())
+      .migrated(owner.getMigrated())
       .build();
   }
 

--- a/src/main/resources/db/migration/V1.18__Add_Migrated_Field_To_Person_Table.sql
+++ b/src/main/resources/db/migration/V1.18__Add_Migrated_Field_To_Person_Table.sql
@@ -1,0 +1,3 @@
+-- Adds migrated column to person table
+ALTER TABLE person
+    ADD COLUMN migrated boolean;

--- a/src/test/resources/fixtures/createOwnerRequest.json
+++ b/src/test/resources/fixtures/createOwnerRequest.json
@@ -25,7 +25,8 @@
       "isMain": "yes",
       "createUserId": 0,
       "updateUserId": 1,
-      "versioning": 2
+      "versioning": 2,
+      "migrated": true
     }
   }
 }

--- a/src/test/resources/fixtures/createOwnerResponse.json
+++ b/src/test/resources/fixtures/createOwnerResponse.json
@@ -23,7 +23,8 @@
       "isMain": "yes",
       "createUserId": 0,
       "updateUserId": 1,
-      "versioning": 2
+      "versioning": 2,
+      "migrated": true
     },
     "relationships": {}
   },

--- a/src/test/resources/fixtures/createOwnerResponseWithDatesSpecified.json
+++ b/src/test/resources/fixtures/createOwnerResponseWithDatesSpecified.json
@@ -25,7 +25,8 @@
       "isMain": "yes",
       "createUserId": 0,
       "updateUserId": 1,
-      "versioning": 2
+      "versioning": 2,
+      "migrated": null
     },
     "relationships": {}
   },


### PR DESCRIPTION
## Context

- Adds a `migrated` column to the `person` table which is where we store the owner to allow us to determine if a user was brought across during a migration attempt
- This will allow us to remove owners on re-runs

## Changes in this pull request

- Adds migration script to add a `migrated` column to the `person` table
- Updates DTOs and mappers to extract `migrated` columns

## Guidance to review

- Have updated the integration tests to check adding the `migrated` column and confirm it is being set still

## Link to Trello card

- https://trello.com/c/S5ESFCUu/780-etl-safe-aggregation-of-owners

## Things to check

- [ ] Environment variables have been updated
