### PR TITLE
Account holder gateway supports updates

### DIFF
--- a/src/main/java/uk/gov/mca/beacons/api/gateways/AccountHolderGateway.java
+++ b/src/main/java/uk/gov/mca/beacons/api/gateways/AccountHolderGateway.java
@@ -9,5 +9,7 @@ public interface AccountHolderGateway {
 
   AccountHolder getByAuthId(String authId);
 
-  AccountHolder save(CreateAccountHolderRequest createAccountHolderRequest);
+  AccountHolder create(CreateAccountHolderRequest createAccountHolderRequest);
+
+  AccountHolder update(UUID id, AccountHolder createAccountHolderRequest);
 }

--- a/src/main/java/uk/gov/mca/beacons/api/gateways/AccountHolderGatewayImpl.java
+++ b/src/main/java/uk/gov/mca/beacons/api/gateways/AccountHolderGatewayImpl.java
@@ -26,7 +26,10 @@ public class AccountHolderGatewayImpl implements AccountHolderGateway {
   private final ModelPatcherFactory<AccountHolder> accountHolderPatcherFactory;
 
   @Autowired
-  public AccountHolderGatewayImpl(NamedParameterJdbcTemplate jdbcTemplate, ModelPatcherFactory<AccountHolder> accountHolderPatcherFactory) {
+  public AccountHolderGatewayImpl(
+    NamedParameterJdbcTemplate jdbcTemplate,
+    ModelPatcherFactory<AccountHolder> accountHolderPatcherFactory
+  ) {
     this.jdbcTemplate = jdbcTemplate;
     this.accountHolderPatcherFactory = accountHolderPatcherFactory;
   }

--- a/src/main/java/uk/gov/mca/beacons/api/gateways/AccountHolderGatewayImpl.java
+++ b/src/main/java/uk/gov/mca/beacons/api/gateways/AccountHolderGatewayImpl.java
@@ -237,9 +237,12 @@ public class AccountHolderGatewayImpl implements AccountHolderGateway {
       .withMapping(AccountHolder::getPostcode, AccountHolder::setPostcode)
       .withMapping(AccountHolder::getCounty, AccountHolder::setCounty);
 
-    var updatedModel = patcher.patchModel(accountHolder, accountHolderUpdate);
+    final var updatedModel = patcher.patchModel(
+      accountHolder,
+      accountHolderUpdate
+    );
 
-    var personParamMap = new MapSqlParameterSource()
+    final var personParamMap = new MapSqlParameterSource()
       .addValue("accountId", id)
       .addValue("fullName", updatedModel.getFullName())
       .addValue("telephoneNumber", updatedModel.getTelephoneNumber())

--- a/src/main/java/uk/gov/mca/beacons/api/jpa/entities/Person.java
+++ b/src/main/java/uk/gov/mca/beacons/api/jpa/entities/Person.java
@@ -8,7 +8,6 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
-import javax.validation.constraints.Email;
 import lombok.Getter;
 import lombok.Setter;
 import uk.gov.mca.beacons.api.domain.PersonType;

--- a/src/main/java/uk/gov/mca/beacons/api/services/AccountHolderService.java
+++ b/src/main/java/uk/gov/mca/beacons/api/services/AccountHolderService.java
@@ -20,7 +20,7 @@ public class AccountHolderService {
   }
 
   public AccountHolder create(CreateAccountHolderRequest accountHolderRequest) {
-    return accountHolderGateway.save(accountHolderRequest);
+    return accountHolderGateway.create(accountHolderRequest);
   }
 
   public AccountHolder getByAuthId(String authId) {

--- a/src/test/java/uk/gov/mca/beacons/api/gateways/AccountHolderGatewayImplTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/gateways/AccountHolderGatewayImplTest.java
@@ -58,7 +58,10 @@ public class AccountHolderGatewayImplTest {
     )
       .willReturn(accountHolder);
 
-    var gateway = new AccountHolderGatewayImpl(jdbcMock, new ModelPatcherFactory<AccountHolder>());
+    var gateway = new AccountHolderGatewayImpl(
+      jdbcMock,
+      new ModelPatcherFactory<AccountHolder>()
+    );
     gateway.update(accountId, accountHolderUpdate);
 
     verify(jdbcMock).update(any(String.class), sqlParamsCaptor.capture());
@@ -112,7 +115,10 @@ public class AccountHolderGatewayImplTest {
     )
       .willReturn(accountHolder);
 
-    var gateway = new AccountHolderGatewayImpl(jdbcMock, new ModelPatcherFactory<AccountHolder>());
+    var gateway = new AccountHolderGatewayImpl(
+      jdbcMock,
+      new ModelPatcherFactory<AccountHolder>()
+    );
     var updatedModel = gateway.update(accountId, accountHolderUpdate);
 
     assertThat(updatedModel.getFullName(), is("Bob Marley"));

--- a/src/test/java/uk/gov/mca/beacons/api/gateways/AccountHolderGatewayImplTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/gateways/AccountHolderGatewayImplTest.java
@@ -1,0 +1,124 @@
+package uk.gov.mca.beacons.api.gateways;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import uk.gov.mca.beacons.api.domain.AccountHolder;
+import uk.gov.mca.beacons.api.mappers.AccountHolderRowMapper;
+import uk.gov.mca.beacons.api.mappers.ModelPatcherFactory;
+
+@ExtendWith(MockitoExtension.class)
+public class AccountHolderGatewayImplTest {
+
+  @Mock
+  private NamedParameterJdbcTemplate jdbcMock;
+
+  @Captor
+  ArgumentCaptor<MapSqlParameterSource> sqlParamsCaptor;
+
+  @Test
+  void shouldCallUpdateWithCorrectSqlParams() {
+    UUID accountId = UUID.randomUUID();
+    AccountHolder accountHolder = new AccountHolder();
+    AccountHolder accountHolderUpdate = AccountHolder
+      .builder()
+      .fullName("Fat Les")
+      .telephoneNumber("1966")
+      .alternativeTelephoneNumber("2021")
+      .addressLine1("Wembley Stadium")
+      .addressLine2("Wembley Park")
+      .addressLine3("Wembley")
+      .addressLine4("Brent")
+      .townOrCity("London")
+      .postcode("V1N6 4LO")
+      .county("England")
+      .build();
+    given(
+      jdbcMock.queryForObject(
+        isA(String.class),
+        isA(MapSqlParameterSource.class),
+        isA(AccountHolderRowMapper.class)
+      )
+    )
+      .willReturn(accountHolder);
+
+    var gateway = new AccountHolderGatewayImpl(jdbcMock, new ModelPatcherFactory<AccountHolder>());
+    gateway.update(accountId, accountHolderUpdate);
+
+    verify(jdbcMock).update(any(String.class), sqlParamsCaptor.capture());
+    var sqlParams = sqlParamsCaptor.getValue().getValues();
+    assertThat(
+      "don't want to add or remove anything",
+      sqlParams.size(),
+      is(12)
+    );
+    assertThat(sqlParams.get("accountId"), is(accountId));
+    assertThat(sqlParams.get("fullName"), is("Fat Les"));
+    assertThat(sqlParams.get("telephoneNumber"), is("1966"));
+    assertThat(sqlParams.get("alternativeTelephoneNumber"), is("2021"));
+    assertThat(sqlParams.get("addressLine1"), is("Wembley Stadium"));
+    assertThat(sqlParams.get("addressLine2"), is("Wembley Park"));
+    assertThat(sqlParams.get("addressLine3"), is("Wembley"));
+    assertThat(sqlParams.get("addressLine4"), is("Brent"));
+    assertThat(sqlParams.get("townOrCity"), is("London"));
+    assertThat(sqlParams.get("postcode"), is("V1N6 4LO"));
+    assertThat(sqlParams.get("county"), is("England"));
+    var modifiedDate = (LocalDateTime) sqlParams.get("lastModifiedDate");
+    assertThat(
+      modifiedDate.getDayOfYear(),
+      is(equalTo(LocalDateTime.now().getDayOfYear()))
+    );
+  }
+
+  @Test
+  void shouldReturnUpdatedModel() {
+    UUID accountId = UUID.randomUUID();
+    AccountHolder accountHolder = AccountHolder
+      .builder()
+      .fullName("Toots")
+      .telephoneNumber("555 54 46 54")
+      .alternativeTelephoneNumber("555 999 999")
+      .addressLine1(null)
+      .addressLine2("")
+      .build();
+    AccountHolder accountHolderUpdate = AccountHolder
+      .builder()
+      .fullName("Bob Marley")
+      .telephoneNumber("555 329 184")
+      .build();
+
+    given(
+      jdbcMock.queryForObject(
+        isA(String.class),
+        isA(MapSqlParameterSource.class),
+        isA(AccountHolderRowMapper.class)
+      )
+    )
+      .willReturn(accountHolder);
+
+    var gateway = new AccountHolderGatewayImpl(jdbcMock, new ModelPatcherFactory<AccountHolder>());
+    var updatedModel = gateway.update(accountId, accountHolderUpdate);
+
+    assertThat(updatedModel.getFullName(), is("Bob Marley"));
+    assertThat(updatedModel.getTelephoneNumber(), is("555 329 184"));
+    assertThat(updatedModel.getAlternativeTelephoneNumber(), is("555 999 999"));
+    assertThat(updatedModel.getAddressLine1(), is(nullValue()));
+    assertThat(updatedModel.getAddressLine2(), is(""));
+  }
+}

--- a/src/test/java/uk/gov/mca/beacons/api/services/AccountHolderServiceTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/services/AccountHolderServiceTest.java
@@ -31,7 +31,7 @@ class AccountHolderServiceTest {
     final CreateAccountHolderRequest accountHolder = new CreateAccountHolderRequest();
     final AccountHolder createdAccountHolder = new AccountHolder();
 
-    given(mockAccountHolderGateway.save(accountHolder))
+    given(mockAccountHolderGateway.create(accountHolder))
       .willReturn(createdAccountHolder);
 
     assertThat(


### PR DESCRIPTION
## Context

Added update method to Account Holder gateway. Will be used by the update-account-holder endpoint.

## Changes in this pull request

**AccountHolderGateway interfac, imp, and tests:** renamed methods to be more cruddy and added a mahoosive update method.

## Guidance to review

just a quick 👀 please

## Link to Trello card

https://trello.com/c/Uowf65bt/683-api-beacon-account-holder-user-can-update-profile-details-on-beacon-api
