### PR TITLE
Account Holder profile updates part2

### DIFF
--- a/src/main/java/uk/gov/mca/beacons/api/controllers/AccountHolderController.java
+++ b/src/main/java/uk/gov/mca/beacons/api/controllers/AccountHolderController.java
@@ -93,7 +93,8 @@ public class AccountHolderController {
 
   @PatchMapping(value = "/{id}")
   @ResponseStatus(HttpStatus.CREATED)
-  public WrapperDTO<AccountHolderDTO> updateAccountHolder(@PathVariable("id") UUID id,
+  public WrapperDTO<AccountHolderDTO> updateAccountHolder(
+    @PathVariable("id") UUID id,
     @RequestBody WrapperDTO<AccountHolderDTO> dto
   ) {
     final AccountHolder newAccountHolderRequest = accountHolderMapper.fromDTO(

--- a/src/main/java/uk/gov/mca/beacons/api/controllers/AccountHolderController.java
+++ b/src/main/java/uk/gov/mca/beacons/api/controllers/AccountHolderController.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -92,7 +93,8 @@ public class AccountHolderController {
   }
 
   @PatchMapping(value = "/{id}")
-  @ResponseStatus(HttpStatus.CREATED)
+  @ResponseStatus(HttpStatus.OK)
+  @PreAuthorize("hasAuthority('APPROLE_UPDATE_RECORDS')")
   public WrapperDTO<AccountHolderDTO> updateAccountHolder(
     @PathVariable("id") UUID id,
     @RequestBody WrapperDTO<AccountHolderDTO> dto

--- a/src/main/java/uk/gov/mca/beacons/api/controllers/AccountHolderController.java
+++ b/src/main/java/uk/gov/mca/beacons/api/controllers/AccountHolderController.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -87,6 +88,20 @@ public class AccountHolderController {
 
     return accountHolderMapper.toWrapperDTO(
       accountHolderService.create(newAccountHolderRequest)
+    );
+  }
+
+  @PatchMapping(value = "/{id}")
+  @ResponseStatus(HttpStatus.CREATED)
+  public WrapperDTO<AccountHolderDTO> updateAccountHolder(@PathVariable("id") UUID id,
+    @RequestBody WrapperDTO<AccountHolderDTO> dto
+  ) {
+    final AccountHolder newAccountHolderRequest = accountHolderMapper.fromDTO(
+      dto.getData()
+    );
+
+    return accountHolderMapper.toWrapperDTO(
+      accountHolderService.update(id, newAccountHolderRequest)
     );
   }
 

--- a/src/main/java/uk/gov/mca/beacons/api/dto/BeaconPersonDTO.java
+++ b/src/main/java/uk/gov/mca/beacons/api/dto/BeaconPersonDTO.java
@@ -4,7 +4,6 @@ import static uk.gov.mca.beacons.api.dto.BeaconPersonDTO.Attributes;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
-import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/uk/gov/mca/beacons/api/dto/RelationshipDTO.java
+++ b/src/main/java/uk/gov/mca/beacons/api/dto/RelationshipDTO.java
@@ -12,6 +12,7 @@ public class RelationshipDTO {
     return data;
   }
 
+  @SuppressWarnings("rawtypes")
   public void addData(DomainDTO domainDto) {
     data.add(new RelationshipData(domainDto.getType(), domainDto.getId()));
   }

--- a/src/main/java/uk/gov/mca/beacons/api/dto/WrapperDTO.java
+++ b/src/main/java/uk/gov/mca/beacons/api/dto/WrapperDTO.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
 
 public class WrapperDTO<T> {
 

--- a/src/main/java/uk/gov/mca/beacons/api/gateways/AccountHolderGatewayImpl.java
+++ b/src/main/java/uk/gov/mca/beacons/api/gateways/AccountHolderGatewayImpl.java
@@ -263,7 +263,7 @@ public class AccountHolderGatewayImpl implements AccountHolderGateway {
       "UPDATE person SET " +
       "full_name = :fullName , " +
       "telephone_number = :telephoneNumber , " +
-      "alternative_telephone_number = :alternative_telephone_number , " +
+      "alternative_telephone_number = :alternativeTelephoneNumber , " +
       "last_modified_date = :lastModifiedDate , " +
       "address_line_1 = :addressLine1 , " +
       "address_line_2 = :addressLine2 , " +

--- a/src/main/java/uk/gov/mca/beacons/api/mappers/BeaconsResponseFactory.java
+++ b/src/main/java/uk/gov/mca/beacons/api/mappers/BeaconsResponseFactory.java
@@ -116,6 +116,7 @@ public class BeaconsResponseFactory {
       .collect(Collectors.toList());
   }
 
+  @SuppressWarnings("rawtypes")
   private BeaconDTO buildBeaconDTO(
     Beacon beacon,
     List<BeaconUseDTO> useDTOs,

--- a/src/main/java/uk/gov/mca/beacons/api/mappers/RelationshipMapper.java
+++ b/src/main/java/uk/gov/mca/beacons/api/mappers/RelationshipMapper.java
@@ -6,6 +6,7 @@ import uk.gov.mca.beacons.api.dto.DomainDTO;
 import uk.gov.mca.beacons.api.dto.RelationshipDTO;
 
 @Service
+@SuppressWarnings("rawtypes")
 public class RelationshipMapper {
 
   public RelationshipDTO toDTO(DomainDTO related) {

--- a/src/main/java/uk/gov/mca/beacons/api/services/AccountHolderService.java
+++ b/src/main/java/uk/gov/mca/beacons/api/services/AccountHolderService.java
@@ -23,6 +23,10 @@ public class AccountHolderService {
     return accountHolderGateway.create(accountHolderRequest);
   }
 
+  public AccountHolder update(UUID id, AccountHolder accountHolderRequest) {
+    return accountHolderGateway.update(id, accountHolderRequest);
+  }
+
   public AccountHolder getByAuthId(String authId) {
     return accountHolderGateway.getByAuthId(authId);
   }

--- a/src/test/java/uk/gov/mca/beacons/api/controllers/AccountHolderControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/controllers/AccountHolderControllerIntegrationTest.java
@@ -166,6 +166,36 @@ class AccountHolderControllerIntegrationTest {
     }
   }
 
+  @Nested
+  class UpdateAccountHolderIdByAuthId {
+
+    @Test
+    void shouldReturnTheIdForTheAccountHolderByAuthId() throws Exception {
+      final var authId = UUID.randomUUID().toString();
+      final var accountHolderId = createAccountHolder(authId);
+
+      String updateRequest = readFile(
+        "src/test/resources/fixtures/updateAccountHolderRequest.json"
+      )
+        .replace("replace-with-test-account-id", accountHolderId);
+      String expectedResponse = readFile(
+        "src/test/resources/fixtures/updateAccountHolderResponse.json"
+      )
+        .replace("replace-with-test-account-id", accountHolderId);
+
+      var response = webTestClient
+        .patch()
+        .uri("/account-holder/" + accountHolderId)
+        .body(BodyInserters.fromValue(updateRequest))
+        .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+        .exchange()
+        .expectBody();
+
+      response.json(expectedResponse);
+      response.jsonPath("$.data.id").isNotEmpty();
+    }
+  }
+
   private String readFile(String filePath) throws IOException {
     return new String(Files.readAllBytes(Paths.get(filePath)));
   }

--- a/src/test/java/uk/gov/mca/beacons/api/controllers/AccountHolderControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/controllers/AccountHolderControllerIntegrationTest.java
@@ -170,7 +170,7 @@ class AccountHolderControllerIntegrationTest {
   class UpdateAccountHolderIdByAuthId {
 
     @Test
-    void shouldReturnTheIdForTheAccountHolderByAuthId() throws Exception {
+    void shouldReturnTheUpdatedAccountHolderByAuthId() throws Exception {
       final var authId = UUID.randomUUID().toString();
       final var accountHolderId = createAccountHolder(authId);
 

--- a/src/test/java/uk/gov/mca/beacons/api/mappers/PersonMapperUnitTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/mappers/PersonMapperUnitTest.java
@@ -15,7 +15,6 @@ class PersonMapperUnitTest {
     final var beaconPersonMapper = new BeaconPersonMapper();
     final Person person = new Person();
     final UUID personId = UUID.randomUUID();
-    final UUID beaconId = UUID.randomUUID();
     final String fullName = "Phoebe Buffay";
     final String telephoneNumber = "07777777777";
     final String telephoneNumber2 = "07888888888";

--- a/src/test/resources/fixtures/updateAccountHolderRequest.json
+++ b/src/test/resources/fixtures/updateAccountHolderRequest.json
@@ -1,0 +1,18 @@
+{
+  "meta": {},
+  "included": [],
+  "data": {
+    "id": "replace-with-test-account-id",
+    "type": "accountHolder",
+    "relationships": {},
+    "attributes": {
+      "fullName": "Updatey McUpdateface",
+      "telephoneNumber": "01178 919191",
+      "addressLine1": "Number 44",
+      "addressLine2": "Updatey Towers",
+      "addressLine3": "Updatey Test",
+      "addressLine4": "",
+      "postcode": "UP1 23A"
+    }
+  }
+}

--- a/src/test/resources/fixtures/updateAccountHolderResponse.json
+++ b/src/test/resources/fixtures/updateAccountHolderResponse.json
@@ -4,7 +4,6 @@
     "id": "replace-with-test-account-id",
     "type": "accountHolder",
     "attributes": {
-      "authId": "replace-with-test-auth-id",
       "email": "testy@mctestface.com",
       "fullName": "Updatey McUpdateface",
       "telephoneNumber": "01178 919191",

--- a/src/test/resources/fixtures/updateAccountHolderResponse.json
+++ b/src/test/resources/fixtures/updateAccountHolderResponse.json
@@ -1,0 +1,23 @@
+{
+  "meta": {},
+  "data": {
+    "id": "replace-with-test-account-id",
+    "type": "accountHolder",
+    "attributes": {
+      "authId": "replace-with-test-auth-id",
+      "email": "testy@mctestface.com",
+      "fullName": "Updatey McUpdateface",
+      "telephoneNumber": "01178 919191",
+      "alternativeTelephoneNumber": "01178 657124",
+      "addressLine1": "Number 44",
+      "addressLine2": "Updatey Towers",
+      "addressLine3": "Updatey Test",
+      "addressLine4": "",
+      "townOrCity": "Testville",
+      "postcode": "UP1 23A",
+      "county": "Testershire"
+    },
+    "relationships": {}
+  },
+  "included": []
+}


### PR DESCRIPTION
## Context

API endpoint and service for the account holder updating gateway calls we did earlier

## Changes in this pull request

AccountHolderController.java : new endpoint
AccountHolderControllerIntegrationTest.java : test the above
AccountHolderService.java : plumbing the endpoint to the jdbc gateway

plus a few tidyings which i couldn't resist, soz.

## Guidance to review

Run the integration test `shouldReturnTheUpdatedAccountHolderByAuthId` (integration tests fail locally when run via vsCode on my box, cmd is your friend)

## Link to Trello card

https://trello.com/c/Uowf65bt/683-api-beacon-account-holder-user-can-update-profile-details-on-beacon-api
