### PR TITLE
Update NoteGateway and add NoteService

### DIFF
--- a/src/main/java/uk/gov/mca/beacons/api/BeaconsApi.java
+++ b/src/main/java/uk/gov/mca/beacons/api/BeaconsApi.java
@@ -1,12 +1,19 @@
 package uk.gov.mca.beacons.api;
 
+import java.time.Clock;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class BeaconsApi {
 
   public static void main(String[] args) {
     SpringApplication.run(BeaconsApi.class, args);
+  }
+
+  @Bean
+  Clock clock() {
+    return Clock.systemDefaultZone();
   }
 }

--- a/src/main/java/uk/gov/mca/beacons/api/domain/Note.java
+++ b/src/main/java/uk/gov/mca/beacons/api/domain/Note.java
@@ -2,13 +2,17 @@ package uk.gov.mca.beacons.api.domain;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Note {
 
   private UUID id;

--- a/src/main/java/uk/gov/mca/beacons/api/gateways/NoteGateway.java
+++ b/src/main/java/uk/gov/mca/beacons/api/gateways/NoteGateway.java
@@ -3,5 +3,5 @@ package uk.gov.mca.beacons.api.gateways;
 import uk.gov.mca.beacons.api.domain.Note;
 
 public interface NoteGateway {
-  void create(Note note);
+  Note create(Note note);
 }

--- a/src/main/java/uk/gov/mca/beacons/api/gateways/NoteGatewayImpl.java
+++ b/src/main/java/uk/gov/mca/beacons/api/gateways/NoteGatewayImpl.java
@@ -14,8 +14,9 @@ public class NoteGatewayImpl implements NoteGateway {
   }
 
   @Override
-  public void create(Note note) {
+  public Note create(Note note) {
     final NoteEntity noteEntity = NoteMapper.toNoteEntity(note);
-    this.noteJpaRepository.save(noteEntity);
+    final NoteEntity createdNote = noteJpaRepository.save(noteEntity);
+    return NoteMapper.fromNoteEntity(createdNote);
   }
 }

--- a/src/main/java/uk/gov/mca/beacons/api/gateways/NoteGatewayImpl.java
+++ b/src/main/java/uk/gov/mca/beacons/api/gateways/NoteGatewayImpl.java
@@ -1,10 +1,14 @@
 package uk.gov.mca.beacons.api.gateways;
 
+import javax.transaction.Transactional;
+import org.springframework.stereotype.Repository;
 import uk.gov.mca.beacons.api.domain.Note;
 import uk.gov.mca.beacons.api.jpa.NoteJpaRepository;
 import uk.gov.mca.beacons.api.jpa.entities.NoteEntity;
 import uk.gov.mca.beacons.api.mappers.NoteMapper;
 
+@Repository
+@Transactional
 public class NoteGatewayImpl implements NoteGateway {
 
   private NoteJpaRepository noteJpaRepository;

--- a/src/main/java/uk/gov/mca/beacons/api/gateways/NoteGatewayImpl.java
+++ b/src/main/java/uk/gov/mca/beacons/api/gateways/NoteGatewayImpl.java
@@ -11,15 +11,20 @@ import uk.gov.mca.beacons.api.mappers.NoteMapper;
 @Transactional
 public class NoteGatewayImpl implements NoteGateway {
 
+  private NoteMapper noteMapper;
   private NoteJpaRepository noteJpaRepository;
 
-  public NoteGatewayImpl(NoteJpaRepository noteRepository) {
+  public NoteGatewayImpl(
+    NoteMapper noteMapper,
+    NoteJpaRepository noteRepository
+  ) {
+    this.noteMapper = noteMapper;
     this.noteJpaRepository = noteRepository;
   }
 
   @Override
   public Note create(Note note) {
-    final NoteEntity noteEntity = NoteMapper.toNoteEntity(note);
+    final NoteEntity noteEntity = noteMapper.toNoteEntity(note);
     final NoteEntity createdEntity = noteJpaRepository.save(noteEntity);
     return NoteMapper.fromNoteEntity(createdEntity);
   }

--- a/src/main/java/uk/gov/mca/beacons/api/gateways/NoteGatewayImpl.java
+++ b/src/main/java/uk/gov/mca/beacons/api/gateways/NoteGatewayImpl.java
@@ -20,7 +20,7 @@ public class NoteGatewayImpl implements NoteGateway {
   @Override
   public Note create(Note note) {
     final NoteEntity noteEntity = NoteMapper.toNoteEntity(note);
-    final NoteEntity createdNote = noteJpaRepository.save(noteEntity);
-    return NoteMapper.fromNoteEntity(createdNote);
+    final NoteEntity createdEntity = noteJpaRepository.save(noteEntity);
+    return NoteMapper.fromNoteEntity(createdEntity);
   }
 }

--- a/src/main/java/uk/gov/mca/beacons/api/jpa/entities/NoteEntity.java
+++ b/src/main/java/uk/gov/mca/beacons/api/jpa/entities/NoteEntity.java
@@ -7,13 +7,19 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import uk.gov.mca.beacons.api.domain.NoteType;
 
 @Entity(name = "note")
 @Getter
 @Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class NoteEntity {
 
   @Id

--- a/src/main/java/uk/gov/mca/beacons/api/mappers/NoteMapper.java
+++ b/src/main/java/uk/gov/mca/beacons/api/mappers/NoteMapper.java
@@ -23,4 +23,18 @@ public class NoteMapper {
 
     return noteEntity;
   }
+
+  public static Note fromNoteEntity(NoteEntity noteEntity) {
+    return Note
+      .builder()
+      .id(noteEntity.getId())
+      .beaconId(noteEntity.getBeaconId())
+      .text(noteEntity.getText())
+      .type(noteEntity.getType())
+      .createdDate(noteEntity.getCreatedDate())
+      .personId(noteEntity.getPersonId())
+      .fullName(noteEntity.getFullName())
+      .email(noteEntity.getEmail())
+      .build();
+  }
 }

--- a/src/main/java/uk/gov/mca/beacons/api/mappers/NoteMapper.java
+++ b/src/main/java/uk/gov/mca/beacons/api/mappers/NoteMapper.java
@@ -25,16 +25,27 @@ public class NoteMapper {
   }
 
   public static Note fromNoteEntity(NoteEntity noteEntity) {
-    return Note
-      .builder()
-      .id(noteEntity.getId())
-      .beaconId(noteEntity.getBeaconId())
-      .text(noteEntity.getText())
-      .type(noteEntity.getType())
-      .createdDate(noteEntity.getCreatedDate())
-      .personId(noteEntity.getPersonId())
-      .fullName(noteEntity.getFullName())
-      .email(noteEntity.getEmail())
-      .build();
+    Note note = new Note();
+
+    note.setId(noteEntity.getId());
+    note.setBeaconId(noteEntity.getBeaconId());
+    note.setText(noteEntity.getText());
+    note.setType(noteEntity.getType());
+    note.setCreatedDate(noteEntity.getCreatedDate());
+    note.setPersonId(noteEntity.getPersonId());
+    note.setFullName(noteEntity.getFullName());
+    note.setEmail(noteEntity.getEmail());
+
+    return note;
+    //      .builder()
+    //      .id(noteEntity.getId())
+    //      .beaconId(noteEntity.getBeaconId())
+    //      .text(noteEntity.getText())
+    //      .type(noteEntity.getType())
+    //      .createdDate(noteEntity.getCreatedDate())
+    //      .personId(noteEntity.getPersonId())
+    //      .fullName(noteEntity.getFullName())
+    //      .email(noteEntity.getEmail())
+    //      .build();
   }
 }

--- a/src/main/java/uk/gov/mca/beacons/api/mappers/NoteMapper.java
+++ b/src/main/java/uk/gov/mca/beacons/api/mappers/NoteMapper.java
@@ -9,43 +9,30 @@ public class NoteMapper {
   public static NoteEntity toNoteEntity(Note note) {
     final LocalDateTime now = LocalDateTime.now();
 
-    NoteEntity noteEntity = new NoteEntity();
-    noteEntity.setId(note.getId());
-    noteEntity.setBeaconId(note.getBeaconId());
-    noteEntity.setText(note.getText());
-    noteEntity.setType(note.getType());
-    noteEntity.setCreatedDate(
-      note.getCreatedDate() == null ? now : note.getCreatedDate()
-    );
-    noteEntity.setPersonId(note.getPersonId());
-    noteEntity.setFullName(note.getFullName());
-    noteEntity.setEmail(note.getEmail());
-
-    return noteEntity;
+    return NoteEntity
+      .builder()
+      .id(note.getId())
+      .beaconId(note.getBeaconId())
+      .text(note.getText())
+      .type(note.getType())
+      .createdDate(note.getCreatedDate() == null ? now : note.getCreatedDate())
+      .personId(note.getPersonId())
+      .fullName(note.getFullName())
+      .email(note.getEmail())
+      .build();
   }
 
   public static Note fromNoteEntity(NoteEntity noteEntity) {
-    Note note = new Note();
-
-    note.setId(noteEntity.getId());
-    note.setBeaconId(noteEntity.getBeaconId());
-    note.setText(noteEntity.getText());
-    note.setType(noteEntity.getType());
-    note.setCreatedDate(noteEntity.getCreatedDate());
-    note.setPersonId(noteEntity.getPersonId());
-    note.setFullName(noteEntity.getFullName());
-    note.setEmail(noteEntity.getEmail());
-
-    return note;
-    //      .builder()
-    //      .id(noteEntity.getId())
-    //      .beaconId(noteEntity.getBeaconId())
-    //      .text(noteEntity.getText())
-    //      .type(noteEntity.getType())
-    //      .createdDate(noteEntity.getCreatedDate())
-    //      .personId(noteEntity.getPersonId())
-    //      .fullName(noteEntity.getFullName())
-    //      .email(noteEntity.getEmail())
-    //      .build();
+    return Note
+      .builder()
+      .id(noteEntity.getId())
+      .beaconId(noteEntity.getBeaconId())
+      .text(noteEntity.getText())
+      .type(noteEntity.getType())
+      .createdDate(noteEntity.getCreatedDate())
+      .personId(noteEntity.getPersonId())
+      .fullName(noteEntity.getFullName())
+      .email(noteEntity.getEmail())
+      .build();
   }
 }

--- a/src/main/java/uk/gov/mca/beacons/api/mappers/NoteMapper.java
+++ b/src/main/java/uk/gov/mca/beacons/api/mappers/NoteMapper.java
@@ -1,13 +1,24 @@
 package uk.gov.mca.beacons.api.mappers;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 import uk.gov.mca.beacons.api.domain.Note;
 import uk.gov.mca.beacons.api.jpa.entities.NoteEntity;
 
+@Service
 public class NoteMapper {
 
-  public static NoteEntity toNoteEntity(Note note) {
-    final LocalDateTime now = LocalDateTime.now();
+  private Clock clock;
+
+  @Autowired
+  public NoteMapper(Clock clock) {
+    this.clock = clock;
+  }
+
+  public NoteEntity toNoteEntity(Note note) {
+    final LocalDateTime now = LocalDateTime.now(clock);
 
     return NoteEntity
       .builder()

--- a/src/main/java/uk/gov/mca/beacons/api/mappers/NoteMapper.java
+++ b/src/main/java/uk/gov/mca/beacons/api/mappers/NoteMapper.java
@@ -1,17 +1,22 @@
 package uk.gov.mca.beacons.api.mappers;
 
+import java.time.LocalDateTime;
 import uk.gov.mca.beacons.api.domain.Note;
 import uk.gov.mca.beacons.api.jpa.entities.NoteEntity;
 
 public class NoteMapper {
 
   public static NoteEntity toNoteEntity(Note note) {
+    final LocalDateTime now = LocalDateTime.now();
+
     NoteEntity noteEntity = new NoteEntity();
     noteEntity.setId(note.getId());
     noteEntity.setBeaconId(note.getBeaconId());
     noteEntity.setText(note.getText());
     noteEntity.setType(note.getType());
-    noteEntity.setCreatedDate(note.getCreatedDate());
+    noteEntity.setCreatedDate(
+      note.getCreatedDate() == null ? now : note.getCreatedDate()
+    );
     noteEntity.setPersonId(note.getPersonId());
     noteEntity.setFullName(note.getFullName());
     noteEntity.setEmail(note.getEmail());

--- a/src/main/java/uk/gov/mca/beacons/api/services/NoteService.java
+++ b/src/main/java/uk/gov/mca/beacons/api/services/NoteService.java
@@ -1,0 +1,23 @@
+package uk.gov.mca.beacons.api.services;
+
+import javax.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.mca.beacons.api.domain.Note;
+import uk.gov.mca.beacons.api.gateways.NoteGateway;
+
+@Service
+@Transactional
+public class NoteService {
+
+  private final NoteGateway noteGateway;
+
+  @Autowired
+  public NoteService(NoteGateway noteGateway) {
+    this.noteGateway = noteGateway;
+  }
+
+  public Note create(Note note) {
+    return noteGateway.create(note);
+  }
+}

--- a/src/test/java/uk/gov/mca/beacons/api/gateways/NoteGatewayImplTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/gateways/NoteGatewayImplTest.java
@@ -3,7 +3,8 @@ package uk.gov.mca.beacons.api.gateways;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.verify;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -33,6 +34,7 @@ class NoteGatewayImplTest {
 
   @Test
   void shouldCreateANoteEntityFromANote() {
+    final UUID id = UUID.randomUUID();
     final UUID beaconId = UUID.randomUUID();
     final String text = "This beacon belongs to a cat.";
     final NoteType type = NoteType.GENERAL;
@@ -52,11 +54,23 @@ class NoteGatewayImplTest {
       .email(email)
       .build();
 
-    noteGateway.create(note);
+    final NoteEntity createdEntity = NoteEntity
+      .builder()
+      .id(id)
+      .beaconId(beaconId)
+      .text(text)
+      .type(type)
+      .createdDate(createdDate)
+      .personId(personId)
+      .fullName(fullName)
+      .email(email)
+      .build();
 
-    verify(noteRepository).save(noteCaptor.capture());
-    final NoteEntity createdNote = noteCaptor.getValue();
+    when(noteRepository.save(any(NoteEntity.class))).thenReturn(createdEntity);
 
+    final Note createdNote = noteGateway.create(note);
+
+    assertThat(createdNote.getId(), is(id));
     assertThat(createdNote.getBeaconId(), is(beaconId));
     assertThat(createdNote.getText(), is(text));
     assertThat(createdNote.getType(), is(type));
@@ -68,14 +82,16 @@ class NoteGatewayImplTest {
 
   @Test
   void shouldSetCreatedDateIfNotProvided() {
-    final Note note = Note.builder().build();
+    final Note note = new Note();
+    final NoteEntity createdNote = new NoteEntity();
+
+    when(noteRepository.save(noteCaptor.capture())).thenReturn(createdNote);
 
     noteGateway.create(note);
 
-    verify(noteRepository).save(noteCaptor.capture());
-    final NoteEntity createdNote = noteCaptor.getValue();
+    final NoteEntity createdEntity = noteCaptor.getValue();
     assertThat(
-      createdNote.getCreatedDate().getDayOfYear(),
+      createdEntity.getCreatedDate().getDayOfYear(),
       is(equalTo(LocalDateTime.now().getDayOfYear()))
     );
   }

--- a/src/test/java/uk/gov/mca/beacons/api/gateways/NoteGatewayImplTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/gateways/NoteGatewayImplTest.java
@@ -1,11 +1,14 @@
 package uk.gov.mca.beacons.api.gateways;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.verify;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
+import org.apache.tomcat.jni.Local;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -63,5 +66,19 @@ class NoteGatewayImplTest {
     assertThat(createdNote.getPersonId(), is(personId));
     assertThat(createdNote.getFullName(), is(fullName));
     assertThat(createdNote.getEmail(), is(email));
+  }
+
+  @Test
+  void shouldSetCreatedDateIfNotProvided() {
+    final Note note = Note.builder().build();
+
+    noteGateway.create(note);
+
+    verify(noteRepository).save(noteCaptor.capture());
+    final NoteEntity createdNote = noteCaptor.getValue();
+    assertThat(
+      createdNote.getCreatedDate().getDayOfYear(),
+      is(equalTo(LocalDateTime.now().getDayOfYear()))
+    );
   }
 }

--- a/src/test/java/uk/gov/mca/beacons/api/gateways/NoteGatewayImplTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/gateways/NoteGatewayImplTest.java
@@ -83,15 +83,15 @@ class NoteGatewayImplTest {
   @Test
   void shouldSetCreatedDateIfNotProvided() {
     final Note note = new Note();
-    final NoteEntity createdNote = new NoteEntity();
+    final NoteEntity createdEntity = new NoteEntity();
 
-    when(noteRepository.save(noteCaptor.capture())).thenReturn(createdNote);
+    when(noteRepository.save(noteCaptor.capture())).thenReturn(createdEntity);
 
     noteGateway.create(note);
 
-    final NoteEntity createdEntity = noteCaptor.getValue();
+    final NoteEntity entity = noteCaptor.getValue();
     assertThat(
-      createdEntity.getCreatedDate().getDayOfYear(),
+      entity.getCreatedDate().getDayOfYear(),
       is(equalTo(LocalDateTime.now().getDayOfYear()))
     );
   }

--- a/src/test/java/uk/gov/mca/beacons/api/gateways/NoteGatewayImplTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/gateways/NoteGatewayImplTest.java
@@ -5,10 +5,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.verify;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
-import org.apache.tomcat.jni.Local;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;

--- a/src/test/java/uk/gov/mca/beacons/api/services/NoteServiceTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/services/NoteServiceTest.java
@@ -1,0 +1,33 @@
+package uk.gov.mca.beacons.api.services;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.BDDMockito.given;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.mca.beacons.api.domain.Note;
+import uk.gov.mca.beacons.api.gateways.NoteGateway;
+
+@ExtendWith(MockitoExtension.class)
+class NoteServiceTest {
+
+  @Mock
+  private NoteGateway mockNoteGateway;
+
+  @Test
+  void shouldCreateTheNote() {
+    final NoteService noteService = new NoteService(mockNoteGateway);
+    final Note note = new Note();
+    final Note createdNote = Note
+      .builder()
+      .createdDate(LocalDateTime.now())
+      .build();
+
+    given(mockNoteGateway.create(note)).willReturn(createdNote);
+    assertThat(noteService.create(note), is(createdNote));
+  }
+}


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Another [tiny slice](https://www.youtube.com/watch?v=pNZ7DWmZq1I).... 🍰 

## Changes in this pull request

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
- Get `NoteMapper` to set `createdDate` to `now` if the `Note` doesn't have one already
- Add another method to the `NoteMapper` that takes a `NoteEntity` and makes a `Note` out of it
<img src="https://media.giphy.com/media/lXCLl5mExlNbG/giphy.gif"> </img>

- Make `create` method on `NoteGateway` return the created Note
- Add a NoteService
- Annotationnsssssss - have I added the appropriate ones?
- Update/fix tests
   - This bit hurt my brain 

## Link to Trello card
Still this one: https://trello.com/c/S2nXSR2x/675-api-back-office-users-need-ability-to-add-incident-notes-to-a-beacon-record
