### PR TITLE
Add AuthGateway 

### DIFF
--- a/src/main/java/uk/gov/mca/beacons/api/domain/User.java
+++ b/src/main/java/uk/gov/mca/beacons/api/domain/User.java
@@ -1,0 +1,16 @@
+package uk.gov.mca.beacons.api.domain;
+
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class User {
+
+  private UUID authId;
+  private String fullName;
+  private String email;
+}

--- a/src/main/java/uk/gov/mca/beacons/api/gateways/AuthGateway.java
+++ b/src/main/java/uk/gov/mca/beacons/api/gateways/AuthGateway.java
@@ -1,0 +1,7 @@
+package uk.gov.mca.beacons.api.gateways;
+
+import uk.gov.mca.beacons.api.domain.User;
+
+public interface AuthGateway {
+  User getUser();
+}

--- a/src/main/java/uk/gov/mca/beacons/api/gateways/AuthGateway.java
+++ b/src/main/java/uk/gov/mca/beacons/api/gateways/AuthGateway.java
@@ -1,7 +1,11 @@
 package uk.gov.mca.beacons.api.gateways;
 
+import java.util.List;
 import uk.gov.mca.beacons.api.domain.User;
+import uk.gov.mca.beacons.api.gateways.AuthGatewayImpl.SupportedPermissions;
 
 public interface AuthGateway {
   User getUser();
+
+  List<SupportedPermissions> getUserRoles();
 }

--- a/src/main/java/uk/gov/mca/beacons/api/gateways/AuthGatewayImpl.java
+++ b/src/main/java/uk/gov/mca/beacons/api/gateways/AuthGatewayImpl.java
@@ -1,0 +1,27 @@
+package uk.gov.mca.beacons.api.gateways;
+
+import com.azure.spring.aad.webapi.AADOAuth2AuthenticatedPrincipal;
+import java.util.UUID;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import uk.gov.mca.beacons.api.domain.User;
+
+public class AuthGatewayImpl implements AuthGateway {
+
+  public User getUser() {
+    final var authentication = getAuthentication();
+    final var user = (AADOAuth2AuthenticatedPrincipal) authentication.getPrincipal();
+    final var userAttributes = user.getAttributes();
+
+    //    TODO: how to handle "Beacon Registry" notes
+    UUID authId = UUID.fromString((String) userAttributes.get("oid"));
+    String name = (String) userAttributes.get("name");
+    String email = (String) userAttributes.get("email");
+
+    return User.builder().authId(authId).fullName(name).email(email).build();
+  }
+
+  private Authentication getAuthentication() {
+    return SecurityContextHolder.getContext().getAuthentication();
+  }
+}

--- a/src/main/java/uk/gov/mca/beacons/api/gateways/AuthGatewayImpl.java
+++ b/src/main/java/uk/gov/mca/beacons/api/gateways/AuthGatewayImpl.java
@@ -1,13 +1,21 @@
 package uk.gov.mca.beacons.api.gateways;
 
 import com.azure.spring.aad.webapi.AADOAuth2AuthenticatedPrincipal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
 import uk.gov.mca.beacons.api.domain.User;
 
+@Component
 public class AuthGatewayImpl implements AuthGateway {
 
+  @Override
   public User getUser() {
     final var authentication = getAuthentication();
     final var user = (AADOAuth2AuthenticatedPrincipal) authentication.getPrincipal();
@@ -21,7 +29,35 @@ public class AuthGatewayImpl implements AuthGateway {
     return User.builder().authId(authId).fullName(name).email(email).build();
   }
 
+  @Override
+  public List<SupportedPermissions> getUserRoles() {
+    final var authentication = getAuthentication();
+
+    if (authentication == null) return new ArrayList<>();
+
+    return authentication
+      .getAuthorities()
+      .stream()
+      .map(this::SupportedPermissionsFromString)
+      .filter(Objects::nonNull)
+      .collect(Collectors.toList());
+  }
+
   private Authentication getAuthentication() {
     return SecurityContextHolder.getContext().getAuthentication();
+  }
+
+  private SupportedPermissions SupportedPermissionsFromString(
+    GrantedAuthority role
+  ) {
+    try {
+      return SupportedPermissions.valueOf(role.toString());
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
+  }
+
+  public enum SupportedPermissions {
+    APPROLE_UPDATE_RECORDS,
   }
 }

--- a/src/main/java/uk/gov/mca/beacons/api/hateoas/BeaconLinkStrategy.java
+++ b/src/main/java/uk/gov/mca/beacons/api/hateoas/BeaconLinkStrategy.java
@@ -7,7 +7,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder;
 import org.springframework.stereotype.Service;
 import uk.gov.mca.beacons.api.controllers.BeaconsController;
-import uk.gov.mca.beacons.api.dto.BeaconDTO;
 import uk.gov.mca.beacons.api.dto.WrapperDTO;
 import uk.gov.mca.beacons.api.jpa.entities.Beacon;
 

--- a/src/main/java/uk/gov/mca/beacons/api/hateoas/BeaconLinkStrategy.java
+++ b/src/main/java/uk/gov/mca/beacons/api/hateoas/BeaconLinkStrategy.java
@@ -1,7 +1,7 @@
 package uk.gov.mca.beacons.api.hateoas;
 
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
-import static uk.gov.mca.beacons.api.hateoas.BeaconRolesService.SupportedPermissions;
+import static uk.gov.mca.beacons.api.gateways.AuthGatewayImpl.SupportedPermissions;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder;
@@ -43,7 +43,7 @@ public class BeaconLinkStrategy implements IHateoasLinkStrategy<Beacon> {
   public String getPatchPath(Beacon domain) {
     final var methodRoute = WebMvcLinkBuilder
       .methodOn(beaconController)
-      .update(domain.getId(), new WrapperDTO<BeaconDTO>());
+      .update(domain.getId(), new WrapperDTO<>());
     return HateoasLinkPathBuilder.build(linkTo(methodRoute));
   }
 }

--- a/src/main/java/uk/gov/mca/beacons/api/hateoas/BeaconLinkStrategy.java
+++ b/src/main/java/uk/gov/mca/beacons/api/hateoas/BeaconLinkStrategy.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.mca.beacons.api.controllers.BeaconsController;
 import uk.gov.mca.beacons.api.dto.WrapperDTO;
 import uk.gov.mca.beacons.api.jpa.entities.Beacon;
+import uk.gov.mca.beacons.api.services.BeaconRolesService;
 
 @Service
 public class BeaconLinkStrategy implements IHateoasLinkStrategy<Beacon> {

--- a/src/main/java/uk/gov/mca/beacons/api/hateoas/BeaconRolesService.java
+++ b/src/main/java/uk/gov/mca/beacons/api/hateoas/BeaconRolesService.java
@@ -1,40 +1,22 @@
 package uk.gov.mca.beacons.api.hateoas;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import uk.gov.mca.beacons.api.gateways.AuthGateway;
+import uk.gov.mca.beacons.api.gateways.AuthGatewayImpl.SupportedPermissions;
 
 @Service
 public class BeaconRolesService {
 
+  private AuthGateway authGateway;
+
+  @Autowired
+  public BeaconRolesService(AuthGateway authGateway) {
+    this.authGateway = authGateway;
+  }
+
   public List<SupportedPermissions> getUserRoles() {
-    var authentication = SecurityContextHolder.getContext().getAuthentication();
-
-    if (authentication == null) return new ArrayList<>();
-
-    return authentication
-      .getAuthorities()
-      .stream()
-      .map(this::SupportedPermissionsFromString)
-      .filter(Objects::nonNull)
-      .collect(Collectors.toList());
-  }
-
-  private SupportedPermissions SupportedPermissionsFromString(
-    GrantedAuthority role
-  ) {
-    try {
-      return SupportedPermissions.valueOf(role.toString());
-    } catch (IllegalArgumentException e) {
-      return null;
-    }
-  }
-
-  public enum SupportedPermissions {
-    APPROLE_UPDATE_RECORDS,
+    return authGateway.getUserRoles();
   }
 }

--- a/src/main/java/uk/gov/mca/beacons/api/hateoas/BeaconUseLinkStrategy.java
+++ b/src/main/java/uk/gov/mca/beacons/api/hateoas/BeaconUseLinkStrategy.java
@@ -7,7 +7,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder;
 import org.springframework.stereotype.Service;
 import uk.gov.mca.beacons.api.controllers.BeaconUsesController;
-import uk.gov.mca.beacons.api.dto.BeaconUseDTO;
 import uk.gov.mca.beacons.api.dto.WrapperDTO;
 import uk.gov.mca.beacons.api.gateways.AuthGatewayImpl.SupportedPermissions;
 import uk.gov.mca.beacons.api.jpa.entities.BeaconUse;

--- a/src/main/java/uk/gov/mca/beacons/api/hateoas/BeaconUseLinkStrategy.java
+++ b/src/main/java/uk/gov/mca/beacons/api/hateoas/BeaconUseLinkStrategy.java
@@ -1,7 +1,6 @@
 package uk.gov.mca.beacons.api.hateoas;
 
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
-import static uk.gov.mca.beacons.api.hateoas.BeaconRolesService.SupportedPermissions;
 
 import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,6 +9,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.mca.beacons.api.controllers.BeaconUsesController;
 import uk.gov.mca.beacons.api.dto.BeaconUseDTO;
 import uk.gov.mca.beacons.api.dto.WrapperDTO;
+import uk.gov.mca.beacons.api.gateways.AuthGatewayImpl.SupportedPermissions;
 import uk.gov.mca.beacons.api.jpa.entities.BeaconUse;
 
 @Service
@@ -41,7 +41,7 @@ public class BeaconUseLinkStrategy implements IHateoasLinkStrategy<BeaconUse> {
   public String getPatchPath(BeaconUse domain) {
     final var methodRoute = WebMvcLinkBuilder
       .methodOn(beaconUsesController)
-      .update(domain.getId(), new WrapperDTO<BeaconUseDTO>());
+      .update(domain.getId(), new WrapperDTO<>());
     return HateoasLinkPathBuilder.build(linkTo(methodRoute));
   }
 }

--- a/src/main/java/uk/gov/mca/beacons/api/hateoas/BeaconUseLinkStrategy.java
+++ b/src/main/java/uk/gov/mca/beacons/api/hateoas/BeaconUseLinkStrategy.java
@@ -10,6 +10,7 @@ import uk.gov.mca.beacons.api.controllers.BeaconUsesController;
 import uk.gov.mca.beacons.api.dto.WrapperDTO;
 import uk.gov.mca.beacons.api.gateways.AuthGatewayImpl.SupportedPermissions;
 import uk.gov.mca.beacons.api.jpa.entities.BeaconUse;
+import uk.gov.mca.beacons.api.services.BeaconRolesService;
 
 @Service
 public class BeaconUseLinkStrategy implements IHateoasLinkStrategy<BeaconUse> {

--- a/src/main/java/uk/gov/mca/beacons/api/services/BeaconRolesService.java
+++ b/src/main/java/uk/gov/mca/beacons/api/services/BeaconRolesService.java
@@ -1,4 +1,4 @@
-package uk.gov.mca.beacons.api.hateoas;
+package uk.gov.mca.beacons.api.services;
 
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/uk/gov/mca/beacons/api/gateways/AuthGatewayImplTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/gateways/AuthGatewayImplTest.java
@@ -1,25 +1,43 @@
 package uk.gov.mca.beacons.api.gateways;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static uk.gov.mca.beacons.api.gateways.AuthGatewayImpl.SupportedPermissions;
 
 import com.azure.spring.aad.webapi.AADOAuth2AuthenticatedPrincipal;
 import java.util.HashMap;
+import java.util.List;
 import java.util.UUID;
+import org.hamcrest.core.Is;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import uk.gov.mca.beacons.api.domain.User;
 
 @ExtendWith(MockitoExtension.class)
 class AuthGatewayImplTest {
+
+  private AuthGateway authGateway;
+
+  SimpleGrantedAuthority updaterAuth = new SimpleGrantedAuthority(
+    SupportedPermissions.APPROLE_UPDATE_RECORDS.toString()
+  );
+  SimpleGrantedAuthority unsupportedAuth1 = new SimpleGrantedAuthority(
+    "JUNK_AUTH_1"
+  );
+  SimpleGrantedAuthority unsupportedAuth2 = new SimpleGrantedAuthority(
+    "JUNK_AUTH_2"
+  );
 
   Authentication authentication = mock(Authentication.class);
   SecurityContext context = mock(SecurityContext.class);
@@ -32,6 +50,7 @@ class AuthGatewayImplTest {
     given(context.getAuthentication()).willReturn(authentication);
     given(authentication.getPrincipal()).willReturn(principal);
     SecurityContextHolder.setContext(context);
+    authGateway = new AuthGatewayImpl();
   }
 
   @Nested
@@ -49,12 +68,61 @@ class AuthGatewayImplTest {
       mockPrincipal.put("email", email);
       given(principal.getAttributes()).willReturn(mockPrincipal);
 
-      AuthGateway authGateway = new AuthGatewayImpl();
       User user = authGateway.getUser();
 
       assertThat(user.getAuthId(), is(authId));
       assertThat(user.getFullName(), is(fullName));
       assertThat(user.getEmail(), is(email));
+    }
+  }
+
+  @Nested
+  class GetUserRoles {
+
+    @Test
+    void shouldReturnNoPermissionsForNullAuth() {
+      given(context.getAuthentication()).willReturn(null);
+
+      var roles = authGateway.getUserRoles();
+
+      assertThat(roles, Is.is(empty()));
+    }
+
+    @Test
+    void shouldReturnNoPermissionsForRolelessUser() {
+      var roles = authGateway.getUserRoles();
+      assertThat(roles, Is.is(empty()));
+    }
+
+    @Test
+    void shouldReturnPermissionForUpdateRecordsUser() {
+      doReturn(List.of(updaterAuth)).when(authentication).getAuthorities();
+
+      var roles = authGateway.getUserRoles();
+
+      assertThat(roles.size(), Is.is(1));
+    }
+
+    @Test
+    void shouldReturnPermissionForUpdateRecordsUserAndIgnoreUnsupportedPermissions() {
+      doReturn(List.of(unsupportedAuth1, updaterAuth, unsupportedAuth2))
+        .when(authentication)
+        .getAuthorities();
+
+      var roles = authGateway.getUserRoles();
+
+      assertThat(roles.size(), Is.is(1));
+    }
+
+    @Test
+    void shouldReturnIgnoreUnsupportedPermissions() {
+      doReturn(List.of(unsupportedAuth1, unsupportedAuth2))
+        .when(authentication)
+        .getAuthorities();
+
+      var roles = authGateway.getUserRoles();
+
+      assertThat(roles, Is.is(empty()));
     }
   }
 }

--- a/src/test/java/uk/gov/mca/beacons/api/gateways/AuthGatewayImplTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/gateways/AuthGatewayImplTest.java
@@ -1,0 +1,60 @@
+package uk.gov.mca.beacons.api.gateways;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.azure.spring.aad.webapi.AADOAuth2AuthenticatedPrincipal;
+import java.util.HashMap;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import uk.gov.mca.beacons.api.domain.User;
+
+@ExtendWith(MockitoExtension.class)
+class AuthGatewayImplTest {
+
+  Authentication authentication = mock(Authentication.class);
+  SecurityContext context = mock(SecurityContext.class);
+  AADOAuth2AuthenticatedPrincipal principal = mock(
+    AADOAuth2AuthenticatedPrincipal.class
+  );
+
+  @BeforeEach
+  void before() {
+    given(context.getAuthentication()).willReturn(authentication);
+    given(authentication.getPrincipal()).willReturn(principal);
+    SecurityContextHolder.setContext(context);
+  }
+
+  @Nested
+  class GetUser {
+
+    @Test
+    void getsUserAttributesAndCreatesUser() {
+      final UUID authId = UUID.randomUUID();
+      final String fullName = "Marie Antoinette";
+      final String email = "let.them.eat@cake.fr";
+
+      final var mockPrincipal = new HashMap<String, Object>();
+      mockPrincipal.put("oid", authId.toString());
+      mockPrincipal.put("name", fullName);
+      mockPrincipal.put("email", email);
+      given(principal.getAttributes()).willReturn(mockPrincipal);
+
+      AuthGateway authGateway = new AuthGatewayImpl();
+      User user = authGateway.getUser();
+
+      assertThat(user.getAuthId(), is(authId));
+      assertThat(user.getFullName(), is(fullName));
+      assertThat(user.getEmail(), is(email));
+    }
+  }
+}

--- a/src/test/java/uk/gov/mca/beacons/api/hateoas/BeaconLinkStrategyTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/hateoas/BeaconLinkStrategyTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.mca.beacons.api.jpa.entities.Beacon;
+import uk.gov.mca.beacons.api.services.BeaconRolesService;
 
 @ExtendWith(MockitoExtension.class)
 class BeaconLinkStrategyTest {

--- a/src/test/java/uk/gov/mca/beacons/api/hateoas/BeaconLinkStrategyTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/hateoas/BeaconLinkStrategyTest.java
@@ -3,7 +3,7 @@ package uk.gov.mca.beacons.api.hateoas;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.BDDMockito.given;
-import static uk.gov.mca.beacons.api.hateoas.BeaconRolesService.SupportedPermissions;
+import static uk.gov.mca.beacons.api.gateways.AuthGatewayImpl.SupportedPermissions;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,7 +31,7 @@ class BeaconLinkStrategyTest {
     var beaconId = UUID.randomUUID();
     beacon.setId(beaconId);
 
-    userRoles = new ArrayList<SupportedPermissions>();
+    userRoles = new ArrayList<>();
 
     linkStrategy = new BeaconLinkStrategy(beaconRolesService);
   }

--- a/src/test/java/uk/gov/mca/beacons/api/hateoas/BeaconRolesServiceTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/hateoas/BeaconRolesServiceTest.java
@@ -4,91 +4,45 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static uk.gov.mca.beacons.api.hateoas.BeaconRolesService.SupportedPermissions;
 
-import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
+import java.util.ArrayList;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
+import uk.gov.mca.beacons.api.gateways.AuthGateway;
+import uk.gov.mca.beacons.api.gateways.AuthGatewayImpl.SupportedPermissions;
 
 @ExtendWith(MockitoExtension.class)
 class BeaconRolesServiceTest {
 
-  SimpleGrantedAuthority updaterAuth = new SimpleGrantedAuthority(
-    SupportedPermissions.APPROLE_UPDATE_RECORDS.toString()
-  );
-  SimpleGrantedAuthority unsupportedAuth1 = new SimpleGrantedAuthority(
-    "JUNK_AUTH_1"
-  );
-  SimpleGrantedAuthority unsupportedAuth2 = new SimpleGrantedAuthority(
-    "JUNK_AUTH_2"
-  );
+  @InjectMocks
+  private BeaconRolesService beaconRolesService;
 
-  Authentication authentication = mock(Authentication.class);
-  SecurityContext context = mock(SecurityContext.class);
-
-  @BeforeEach
-  void before() {
-    given(context.getAuthentication()).willReturn(authentication);
-    SecurityContextHolder.setContext(context);
-  }
+  @Mock
+  private AuthGateway authGateway;
 
   @Test
-  void ShouldReturnNoPermissionsForNullAuth() {
-    given(context.getAuthentication()).willReturn(null);
-
-    var rolesService = new BeaconRolesService();
-    var roles = rolesService.getUserRoles();
+  void shouldReturnNoPermissionsForRolelessUser() {
+    given(authGateway.getUserRoles()).willReturn(new ArrayList<>());
+    var roles = beaconRolesService.getUserRoles();
 
     assertThat(roles, is(empty()));
   }
 
   @Test
-  void ShouldReturnNoPermissionsForRolelessUser() {
-    var rolesService = new BeaconRolesService();
-    var roles = rolesService.getUserRoles();
+  void shouldReturnPermissionForUpdateRecordsUser() {
+    final var userRoles = new ArrayList<SupportedPermissions>();
+    userRoles.add(SupportedPermissions.APPROLE_UPDATE_RECORDS);
 
-    assertThat(roles, is(empty()));
-  }
-
-  @Test
-  void ShouldReturnPermissionForUpdateRecordsUser() {
-    doReturn(List.of(updaterAuth)).when(authentication).getAuthorities();
-
-    var rolesService = new BeaconRolesService();
-    var roles = rolesService.getUserRoles();
+    given(authGateway.getUserRoles()).willReturn(userRoles);
+    var roles = beaconRolesService.getUserRoles();
 
     assertThat(roles.size(), is(1));
-  }
-
-  @Test
-  void ShouldReturnPermissionForUpdateRecordsUserAndIgnoreUnsupportedPermissions() {
-    doReturn(List.of(unsupportedAuth1, updaterAuth, unsupportedAuth2))
-      .when(authentication)
-      .getAuthorities();
-
-    var rolesService = new BeaconRolesService();
-    var roles = rolesService.getUserRoles();
-
-    assertThat(roles.size(), is(1));
-  }
-
-  @Test
-  void ShouldReturnIgnoreUnsupportedPermissions() {
-    doReturn(List.of(unsupportedAuth1, unsupportedAuth2))
-      .when(authentication)
-      .getAuthorities();
-
-    var rolesService = new BeaconRolesService();
-    var roles = rolesService.getUserRoles();
-
-    assertThat(roles, is(empty()));
+    assertThat(
+      roles.contains(SupportedPermissions.APPROLE_UPDATE_RECORDS),
+      is(true)
+    );
   }
 }

--- a/src/test/java/uk/gov/mca/beacons/api/hateoas/BeaconRolesServiceTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/hateoas/BeaconRolesServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.mca.beacons.api.gateways.AuthGateway;
 import uk.gov.mca.beacons.api.gateways.AuthGatewayImpl.SupportedPermissions;
+import uk.gov.mca.beacons.api.services.BeaconRolesService;
 
 @ExtendWith(MockitoExtension.class)
 class BeaconRolesServiceTest {

--- a/src/test/java/uk/gov/mca/beacons/api/hateoas/BeaconUseLinkStrategyTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/hateoas/BeaconUseLinkStrategyTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.mca.beacons.api.jpa.entities.BeaconUse;
+import uk.gov.mca.beacons.api.services.BeaconRolesService;
 
 @ExtendWith(MockitoExtension.class)
 class BeaconUseLinkStrategyTest {

--- a/src/test/java/uk/gov/mca/beacons/api/hateoas/BeaconUseLinkStrategyTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/hateoas/BeaconUseLinkStrategyTest.java
@@ -4,7 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
-import static uk.gov.mca.beacons.api.hateoas.BeaconRolesService.SupportedPermissions;
+import static uk.gov.mca.beacons.api.gateways.AuthGatewayImpl.SupportedPermissions;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,7 +33,7 @@ class BeaconUseLinkStrategyTest {
     var beaconUseId = UUID.randomUUID();
     beaconUse.setId(beaconUseId);
 
-    userRoles = new ArrayList<SupportedPermissions>();
+    userRoles = new ArrayList<>();
 
     linkStrategy = new BeaconUseLinkStrategy(beaconRolesService);
   }

--- a/src/test/java/uk/gov/mca/beacons/api/hateoas/HateoasLinkManagerTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/hateoas/HateoasLinkManagerTest.java
@@ -3,7 +3,7 @@ package uk.gov.mca.beacons.api.hateoas;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.BDDMockito.given;
-import static uk.gov.mca.beacons.api.hateoas.BeaconRolesService.SupportedPermissions;
+import static uk.gov.mca.beacons.api.gateways.AuthGatewayImpl.SupportedPermissions;
 
 import java.util.ArrayList;
 import java.util.UUID;

--- a/src/test/java/uk/gov/mca/beacons/api/hateoas/HateoasLinkManagerTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/hateoas/HateoasLinkManagerTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.mca.beacons.api.jpa.entities.Beacon;
+import uk.gov.mca.beacons.api.services.BeaconRolesService;
 
 @ExtendWith(MockitoExtension.class)
 class HateoasLinkManagerTest {


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Another slice 🍰 towards notes!

<img height=300 src="https://media.giphy.com/media/xT9IgiMbSAcjUr1TEc/giphy.gif"> </img>

## Changes in this pull request

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
- Add `User` domain object to represent a backoffice User
  - Need to look into how this will work with actions from the webapp (shown as `Beacon Registry` in wireframes)
  - Like when an Account Holder deletes a beacon
- Add `AuthGateway` to get AAD User information from Spring's `SecurityContext`
   - For `Notes`, there's a `getUser` method for getting:
      - `authId` (Azure calls it `oid` aka `ObjectId`),
      - `name`
      - `email`
   - Move the `getUserRoles` method from `BeaconRolesService` into this Gateway
   - Move and add tests
- Trim down `BeaconRolesService` to make it use the `AuthGateway`
## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
- Might be easier to digest by looking at the changes commit by commit?
- I know we've had some issues from not testing unhappy paths before
  - Any suggestions on what is a reasonable one for the `AuthGateway`'s `getUser` method?
  - Finding it hard to think of some right now 🤔  
## Link to Trello card

https://trello.com/c/S2nXSR2x/675-api-back-office-users-need-ability-to-add-incident-notes-to-a-beacon-record
