### PR TITLE
✨ Create note endpoint ✨ 

### DIFF
--- a/src/main/java/uk/gov/mca/beacons/api/controllers/NoteController.java
+++ b/src/main/java/uk/gov/mca/beacons/api/controllers/NoteController.java
@@ -1,0 +1,41 @@
+package uk.gov.mca.beacons.api.controllers;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import javax.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.mca.beacons.api.domain.Note;
+import uk.gov.mca.beacons.api.dto.NoteDTO;
+import uk.gov.mca.beacons.api.dto.WrapperDTO;
+import uk.gov.mca.beacons.api.mappers.NoteMapper;
+import uk.gov.mca.beacons.api.services.NoteService;
+
+@RestController
+@RequestMapping("/note")
+@Tag(name = "Note Controller")
+public class NoteController {
+
+  private final NoteMapper noteMapper;
+  private final NoteService noteService;
+
+  @Autowired
+  public NoteController(NoteMapper noteMapper, NoteService noteService) {
+    this.noteMapper = noteMapper;
+    this.noteService = noteService;
+  }
+
+  @PostMapping
+  @ResponseStatus(HttpStatus.CREATED)
+  public WrapperDTO<NoteDTO> createNote(
+    @RequestBody @Valid WrapperDTO<NoteDTO> dto
+  ) {
+    final Note note = noteMapper.fromDTO(dto.getData());
+
+    return noteMapper.toWrapperDTO(noteService.create(note));
+  }
+}

--- a/src/main/java/uk/gov/mca/beacons/api/controllers/NoteController.java
+++ b/src/main/java/uk/gov/mca/beacons/api/controllers/NoteController.java
@@ -1,10 +1,10 @@
 package uk.gov.mca.beacons.api.controllers;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.UUID;
 import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -40,11 +40,12 @@ public class NoteController {
 
   @PostMapping
   @ResponseStatus(HttpStatus.CREATED)
+  @PreAuthorize("hasAuthority('APPROLE_ADD_BEACON_NOTES')")
   public WrapperDTO<NoteDTO> createNote(
     @RequestBody @Valid WrapperDTO<NoteDTO> dto
   ) {
     final Note note = noteMapper.fromDTO(dto.getData());
-    // TODO: make the id passed in (B2C auth Id) not just null once we're getting that!
+    // TODO: how to handle an Account Holder creating a note?
     final User user = getUserService.getUser(null);
 
     note.setUserId(user.getId());

--- a/src/main/java/uk/gov/mca/beacons/api/controllers/NoteController.java
+++ b/src/main/java/uk/gov/mca/beacons/api/controllers/NoteController.java
@@ -47,7 +47,7 @@ public class NoteController {
     // TODO: make the id passed in (B2C auth Id) not just null once we're getting that!
     final User user = getUserService.getUser(null);
 
-    note.setUserAuthId(UUID.fromString(user.getAuthId()));
+    note.setUserId(UUID.fromString(user.getAuthId()));
     note.setFullName(user.getFullName());
     note.setEmail(user.getEmail());
 

--- a/src/main/java/uk/gov/mca/beacons/api/controllers/NoteController.java
+++ b/src/main/java/uk/gov/mca/beacons/api/controllers/NoteController.java
@@ -48,7 +48,7 @@ public class NoteController {
       // TODO: make the id passed in (B2C auth Id) not just null once we're getting that!
       final User user = getUserService.getUser(null);
 
-      note.setPersonId(UUID.fromString(user.getAuthId()));
+      note.setUserAuthId(UUID.fromString(user.getAuthId()));
       note.setFullName(user.getFullName());
       note.setEmail(user.getEmail());
     }
@@ -57,7 +57,7 @@ public class NoteController {
 
   private boolean userDoesNotExist(Note note) {
     return (
-      note.getPersonId() == null &&
+      note.getUserAuthId() == null &&
       note.getFullName() == null &&
       note.getEmail() == null
     );

--- a/src/main/java/uk/gov/mca/beacons/api/controllers/NoteController.java
+++ b/src/main/java/uk/gov/mca/beacons/api/controllers/NoteController.java
@@ -43,15 +43,9 @@ public class NoteController {
     @RequestBody @Valid WrapperDTO<NoteDTO> dto
   ) {
     final Note note = noteMapper.fromDTO(dto.getData());
-    if (
-      note.getPersonId() == null &&
-      note.getFullName() == null &&
-      note.getEmail() == null
-    ) {
+    if (note.getUser() == null) {
       final User user = getUserService.getUser();
-      note.setPersonId(user.getAuthId());
-      note.setFullName(user.getFullName());
-      note.setEmail(user.getEmail());
+      note.setUser(user);
     }
     return noteMapper.toWrapperDTO(noteService.create(note));
   }

--- a/src/main/java/uk/gov/mca/beacons/api/controllers/NoteController.java
+++ b/src/main/java/uk/gov/mca/beacons/api/controllers/NoteController.java
@@ -44,22 +44,13 @@ public class NoteController {
     @RequestBody @Valid WrapperDTO<NoteDTO> dto
   ) {
     final Note note = noteMapper.fromDTO(dto.getData());
-    if (userDoesNotExist(note)) {
-      // TODO: make the id passed in (B2C auth Id) not just null once we're getting that!
-      final User user = getUserService.getUser(null);
+    // TODO: make the id passed in (B2C auth Id) not just null once we're getting that!
+    final User user = getUserService.getUser(null);
 
-      note.setUserAuthId(UUID.fromString(user.getAuthId()));
-      note.setFullName(user.getFullName());
-      note.setEmail(user.getEmail());
-    }
+    note.setUserAuthId(UUID.fromString(user.getAuthId()));
+    note.setFullName(user.getFullName());
+    note.setEmail(user.getEmail());
+
     return noteMapper.toWrapperDTO(noteService.create(note));
-  }
-
-  private boolean userDoesNotExist(Note note) {
-    return (
-      note.getUserAuthId() == null &&
-      note.getFullName() == null &&
-      note.getEmail() == null
-    );
   }
 }

--- a/src/main/java/uk/gov/mca/beacons/api/controllers/NoteController.java
+++ b/src/main/java/uk/gov/mca/beacons/api/controllers/NoteController.java
@@ -47,7 +47,7 @@ public class NoteController {
     // TODO: make the id passed in (B2C auth Id) not just null once we're getting that!
     final User user = getUserService.getUser(null);
 
-    note.setUserId(UUID.fromString(user.getAuthId()));
+    note.setUserId(user.getId());
     note.setFullName(user.getFullName());
     note.setEmail(user.getEmail());
 

--- a/src/main/java/uk/gov/mca/beacons/api/domain/BackOfficeUser.java
+++ b/src/main/java/uk/gov/mca/beacons/api/domain/BackOfficeUser.java
@@ -1,5 +1,6 @@
 package uk.gov.mca.beacons.api.domain;
 
+import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -9,7 +10,7 @@ import lombok.Setter;
 @Builder
 public class BackOfficeUser implements User {
 
-  private String authId;
+  private UUID id;
   private String fullName;
   private String email;
 }

--- a/src/main/java/uk/gov/mca/beacons/api/domain/Note.java
+++ b/src/main/java/uk/gov/mca/beacons/api/domain/Note.java
@@ -20,7 +20,5 @@ public class Note {
   private String text;
   private NoteType type;
   private LocalDateTime createdDate;
-  private UUID personId;
-  private String fullName;
-  private String email;
+  private User user;
 }

--- a/src/main/java/uk/gov/mca/beacons/api/domain/Note.java
+++ b/src/main/java/uk/gov/mca/beacons/api/domain/Note.java
@@ -20,7 +20,7 @@ public class Note {
   private String text;
   private NoteType type;
   private LocalDateTime createdDate;
-  private UUID personId;
+  private UUID userAuthId;
   private String fullName;
   private String email;
 }

--- a/src/main/java/uk/gov/mca/beacons/api/domain/Note.java
+++ b/src/main/java/uk/gov/mca/beacons/api/domain/Note.java
@@ -20,7 +20,7 @@ public class Note {
   private String text;
   private NoteType type;
   private LocalDateTime createdDate;
-  private UUID userAuthId;
+  private UUID userId;
   private String fullName;
   private String email;
 }

--- a/src/main/java/uk/gov/mca/beacons/api/domain/Note.java
+++ b/src/main/java/uk/gov/mca/beacons/api/domain/Note.java
@@ -20,5 +20,7 @@ public class Note {
   private String text;
   private NoteType type;
   private LocalDateTime createdDate;
-  private User user;
+  private UUID personId;
+  private String fullName;
+  private String email;
 }

--- a/src/main/java/uk/gov/mca/beacons/api/domain/User.java
+++ b/src/main/java/uk/gov/mca/beacons/api/domain/User.java
@@ -1,7 +1,9 @@
 package uk.gov.mca.beacons.api.domain;
 
+import java.util.UUID;
+
 public interface User {
-  String getAuthId();
+  UUID getId();
   String getFullName();
   String getEmail();
 }

--- a/src/main/java/uk/gov/mca/beacons/api/dto/DeleteBeaconRequestDTO.java
+++ b/src/main/java/uk/gov/mca/beacons/api/dto/DeleteBeaconRequestDTO.java
@@ -16,7 +16,7 @@ import lombok.Setter;
 public class DeleteBeaconRequestDTO {
 
   private UUID beaconId;
-  private UUID actorId;
+  private UUID userId;
 
   @NotNull(message = "Reason for deleting a beacon must be defined")
   private String reason;

--- a/src/main/java/uk/gov/mca/beacons/api/dto/NoteDTO.java
+++ b/src/main/java/uk/gov/mca/beacons/api/dto/NoteDTO.java
@@ -1,0 +1,35 @@
+package uk.gov.mca.beacons.api.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import uk.gov.mca.beacons.api.domain.NoteType;
+
+public class NoteDTO extends DomainDTO<NoteDTO.Attributes> {
+
+  private String type = "note";
+
+  public String getType() {
+    return type;
+  }
+
+  @Getter
+  @Setter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class Attributes {
+
+    private UUID beaconId;
+    private String text;
+    private NoteType type;
+    private LocalDateTime createdDate;
+    private UUID personId;
+    private String fullName;
+    private String email;
+  }
+}

--- a/src/main/java/uk/gov/mca/beacons/api/dto/NoteDTO.java
+++ b/src/main/java/uk/gov/mca/beacons/api/dto/NoteDTO.java
@@ -28,7 +28,7 @@ public class NoteDTO extends DomainDTO<NoteDTO.Attributes> {
     private String text;
     private NoteType type;
     private LocalDateTime createdDate;
-    private UUID userAuthId;
+    private UUID userId;
     private String fullName;
     private String email;
   }

--- a/src/main/java/uk/gov/mca/beacons/api/dto/NoteDTO.java
+++ b/src/main/java/uk/gov/mca/beacons/api/dto/NoteDTO.java
@@ -28,7 +28,7 @@ public class NoteDTO extends DomainDTO<NoteDTO.Attributes> {
     private String text;
     private NoteType type;
     private LocalDateTime createdDate;
-    private UUID personId;
+    private UUID userAuthId;
     private String fullName;
     private String email;
   }

--- a/src/main/java/uk/gov/mca/beacons/api/gateways/AuthGatewayImpl.java
+++ b/src/main/java/uk/gov/mca/beacons/api/gateways/AuthGatewayImpl.java
@@ -21,7 +21,6 @@ public class AuthGatewayImpl implements AuthGateway {
     final var user = (AADOAuth2AuthenticatedPrincipal) authentication.getPrincipal();
     final var userAttributes = user.getAttributes();
 
-    //    TODO: how to handle "Beacon Registry" notes
     final String authId = (String) userAttributes.get("oid");
     final String name = (String) userAttributes.get("name");
     final String email = (String) userAttributes.get("email");

--- a/src/main/java/uk/gov/mca/beacons/api/gateways/AuthGatewayImpl.java
+++ b/src/main/java/uk/gov/mca/beacons/api/gateways/AuthGatewayImpl.java
@@ -4,6 +4,7 @@ import com.azure.spring.aad.webapi.AADOAuth2AuthenticatedPrincipal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -21,13 +22,13 @@ public class AuthGatewayImpl implements AuthGateway {
     final var user = (AADOAuth2AuthenticatedPrincipal) authentication.getPrincipal();
     final var userAttributes = user.getAttributes();
 
-    final String authId = (String) userAttributes.get("oid");
+    final UUID userId = UUID.fromString((String) userAttributes.get("oid"));
     final String name = (String) userAttributes.get("name");
     final String email = (String) userAttributes.get("email");
 
     return BackOfficeUser
       .builder()
-      .authId(authId)
+      .id(userId)
       .fullName(name)
       .email(email)
       .build();

--- a/src/main/java/uk/gov/mca/beacons/api/gateways/NoteGatewayImpl.java
+++ b/src/main/java/uk/gov/mca/beacons/api/gateways/NoteGatewayImpl.java
@@ -26,6 +26,6 @@ public class NoteGatewayImpl implements NoteGateway {
   public Note create(Note note) {
     final NoteEntity noteEntity = noteMapper.toNoteEntity(note);
     final NoteEntity createdEntity = noteJpaRepository.save(noteEntity);
-    return NoteMapper.fromNoteEntity(createdEntity);
+    return noteMapper.fromNoteEntity(createdEntity);
   }
 }

--- a/src/main/java/uk/gov/mca/beacons/api/jpa/entities/NoteEntity.java
+++ b/src/main/java/uk/gov/mca/beacons/api/jpa/entities/NoteEntity.java
@@ -35,7 +35,7 @@ public class NoteEntity {
 
   private LocalDateTime createdDate;
 
-  private UUID userAuthId;
+  private UUID userId;
 
   private String fullName;
 

--- a/src/main/java/uk/gov/mca/beacons/api/jpa/entities/NoteEntity.java
+++ b/src/main/java/uk/gov/mca/beacons/api/jpa/entities/NoteEntity.java
@@ -35,7 +35,7 @@ public class NoteEntity {
 
   private LocalDateTime createdDate;
 
-  private UUID personId;
+  private UUID userAuthId;
 
   private String fullName;
 

--- a/src/main/java/uk/gov/mca/beacons/api/mappers/NoteMapper.java
+++ b/src/main/java/uk/gov/mca/beacons/api/mappers/NoteMapper.java
@@ -37,7 +37,7 @@ public class NoteMapper {
       .build();
   }
 
-  public static Note fromNoteEntity(NoteEntity noteEntity) {
+  public Note fromNoteEntity(NoteEntity noteEntity) {
     return Note
       .builder()
       .id(noteEntity.getId())
@@ -51,7 +51,7 @@ public class NoteMapper {
       .build();
   }
 
-  public static Note fromDTO(NoteDTO noteDTO) {
+  public Note fromDTO(NoteDTO noteDTO) {
     return Note
       .builder()
       .id(noteDTO.getId())
@@ -65,7 +65,7 @@ public class NoteMapper {
       .build();
   }
 
-  public static NoteDTO toDTO(Note note) {
+  public NoteDTO toDTO(Note note) {
     final NoteDTO noteDTO = new NoteDTO();
     noteDTO.setId(note.getId());
 
@@ -84,7 +84,7 @@ public class NoteMapper {
     return noteDTO;
   }
 
-  public static WrapperDTO<NoteDTO> toWrapperDTO(Note note) {
+  public WrapperDTO<NoteDTO> toWrapperDTO(Note note) {
     final WrapperDTO<NoteDTO> wrapperDTO = new WrapperDTO<>();
     wrapperDTO.setData(toDTO(note));
     return wrapperDTO;

--- a/src/main/java/uk/gov/mca/beacons/api/mappers/NoteMapper.java
+++ b/src/main/java/uk/gov/mca/beacons/api/mappers/NoteMapper.java
@@ -1,10 +1,14 @@
 package uk.gov.mca.beacons.api.mappers;
 
+import static uk.gov.mca.beacons.api.dto.NoteDTO.Attributes;
+
 import java.time.Clock;
 import java.time.LocalDateTime;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.mca.beacons.api.domain.Note;
+import uk.gov.mca.beacons.api.dto.NoteDTO;
+import uk.gov.mca.beacons.api.dto.WrapperDTO;
 import uk.gov.mca.beacons.api.jpa.entities.NoteEntity;
 
 @Service
@@ -45,5 +49,44 @@ public class NoteMapper {
       .fullName(noteEntity.getFullName())
       .email(noteEntity.getEmail())
       .build();
+  }
+
+  public static Note fromDTO(NoteDTO noteDTO) {
+    return Note
+      .builder()
+      .id(noteDTO.getId())
+      .beaconId(noteDTO.getAttributes().getBeaconId())
+      .text(noteDTO.getAttributes().getText())
+      .type(noteDTO.getAttributes().getType())
+      .createdDate(noteDTO.getAttributes().getCreatedDate())
+      .personId(noteDTO.getAttributes().getPersonId())
+      .fullName(noteDTO.getAttributes().getFullName())
+      .email(noteDTO.getAttributes().getEmail())
+      .build();
+  }
+
+  public static NoteDTO toDTO(Note note) {
+    final NoteDTO noteDTO = new NoteDTO();
+    noteDTO.setId(note.getId());
+
+    final Attributes attributes = Attributes
+      .builder()
+      .beaconId(note.getBeaconId())
+      .text(note.getText())
+      .type(note.getType())
+      .createdDate(note.getCreatedDate())
+      .personId(note.getPersonId())
+      .fullName(note.getFullName())
+      .email(note.getEmail())
+      .build();
+
+    noteDTO.setAttributes(attributes);
+    return noteDTO;
+  }
+
+  public static WrapperDTO<NoteDTO> toWrapperDTO(Note note) {
+    final WrapperDTO<NoteDTO> wrapperDTO = new WrapperDTO<>();
+    wrapperDTO.setData(toDTO(note));
+    return wrapperDTO;
   }
 }

--- a/src/main/java/uk/gov/mca/beacons/api/mappers/NoteMapper.java
+++ b/src/main/java/uk/gov/mca/beacons/api/mappers/NoteMapper.java
@@ -31,7 +31,7 @@ public class NoteMapper extends BaseMapper {
       .text(note.getText())
       .type(note.getType())
       .createdDate(note.getCreatedDate() == null ? now : note.getCreatedDate())
-      .userAuthId(note.getUserAuthId())
+      .userId(note.getUserId())
       .fullName(note.getFullName())
       .email(note.getEmail())
       .build();
@@ -42,7 +42,7 @@ public class NoteMapper extends BaseMapper {
       .builder()
       .id(noteEntity.getId())
       .beaconId(noteEntity.getBeaconId())
-      .userAuthId(noteEntity.getUserAuthId())
+      .userId(noteEntity.getUserId())
       .fullName(noteEntity.getFullName())
       .email(noteEntity.getEmail())
       .text(noteEntity.getText())
@@ -61,7 +61,7 @@ public class NoteMapper extends BaseMapper {
       .text(attributes.getText())
       .type(attributes.getType())
       .createdDate(attributes.getCreatedDate())
-      .userAuthId(attributes.getUserAuthId())
+      .userId(attributes.getUserId())
       .fullName(attributes.getFullName())
       .email(attributes.getEmail())
       .build();
@@ -77,7 +77,7 @@ public class NoteMapper extends BaseMapper {
       .text(note.getText())
       .type(note.getType())
       .createdDate(note.getCreatedDate())
-      .userAuthId(note.getUserAuthId())
+      .userId(note.getUserId())
       .fullName(note.getFullName())
       .email(note.getEmail())
       .build();

--- a/src/main/java/uk/gov/mca/beacons/api/mappers/NoteMapper.java
+++ b/src/main/java/uk/gov/mca/beacons/api/mappers/NoteMapper.java
@@ -7,7 +7,6 @@ import java.time.LocalDateTime;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.mca.beacons.api.domain.Note;
-import uk.gov.mca.beacons.api.domain.User;
 import uk.gov.mca.beacons.api.dto.NoteDTO;
 import uk.gov.mca.beacons.api.dto.WrapperDTO;
 import uk.gov.mca.beacons.api.jpa.entities.NoteEntity;
@@ -24,7 +23,6 @@ public class NoteMapper extends BaseMapper {
 
   public NoteEntity toNoteEntity(Note note) {
     final LocalDateTime now = LocalDateTime.now(clock);
-    final User user = note.getUser();
 
     return NoteEntity
       .builder()
@@ -33,37 +31,28 @@ public class NoteMapper extends BaseMapper {
       .text(note.getText())
       .type(note.getType())
       .createdDate(note.getCreatedDate() == null ? now : note.getCreatedDate())
-      .personId(user.getAuthId())
-      .fullName(user.getFullName())
-      .email(user.getEmail())
+      .personId(note.getPersonId())
+      .fullName(note.getFullName())
+      .email(note.getEmail())
       .build();
   }
 
   public Note fromNoteEntity(NoteEntity noteEntity) {
-    User user = User
-      .builder()
-      .authId(noteEntity.getPersonId())
-      .fullName(noteEntity.getFullName())
-      .email(noteEntity.getEmail())
-      .build();
-
-    Note note = Note
+    return Note
       .builder()
       .id(noteEntity.getId())
       .beaconId(noteEntity.getBeaconId())
+      .personId(noteEntity.getPersonId())
+      .fullName(noteEntity.getFullName())
+      .email(noteEntity.getEmail())
       .text(noteEntity.getText())
       .type(noteEntity.getType())
       .createdDate(noteEntity.getCreatedDate())
       .build();
-
-    note.setUser(user);
-
-    return note;
   }
 
   public Note fromDTO(NoteDTO noteDTO) {
     Attributes attributes = noteDTO.getAttributes();
-    User user = getUserFromAttributes(attributes);
 
     return Note
       .builder()
@@ -72,7 +61,9 @@ public class NoteMapper extends BaseMapper {
       .text(attributes.getText())
       .type(attributes.getType())
       .createdDate(attributes.getCreatedDate())
-      .user(user)
+      .personId(attributes.getPersonId())
+      .fullName(attributes.getFullName())
+      .email(attributes.getEmail())
       .build();
   }
 
@@ -80,17 +71,15 @@ public class NoteMapper extends BaseMapper {
     final NoteDTO noteDTO = new NoteDTO();
     noteDTO.setId(note.getId());
 
-    final User user = note.getUser();
-
     final Attributes attributes = Attributes
       .builder()
       .beaconId(note.getBeaconId())
       .text(note.getText())
       .type(note.getType())
       .createdDate(note.getCreatedDate())
-      .personId(user.getAuthId())
-      .fullName(user.getFullName())
-      .email(user.getEmail())
+      .personId(note.getPersonId())
+      .fullName(note.getFullName())
+      .email(note.getEmail())
       .build();
 
     noteDTO.setAttributes(attributes);
@@ -101,20 +90,5 @@ public class NoteMapper extends BaseMapper {
     final WrapperDTO<NoteDTO> wrapperDTO = new WrapperDTO<>();
     wrapperDTO.setData(toDTO(note));
     return wrapperDTO;
-  }
-
-  private User getUserFromAttributes(Attributes attributes) {
-    if (
-      attributes.getPersonId() == null &&
-      attributes.getFullName() == null &&
-      attributes.getEmail() == null
-    ) return null;
-
-    return User
-      .builder()
-      .authId(attributes.getPersonId())
-      .fullName(attributes.getFullName())
-      .email(attributes.getEmail())
-      .build();
   }
 }

--- a/src/main/java/uk/gov/mca/beacons/api/mappers/NoteMapper.java
+++ b/src/main/java/uk/gov/mca/beacons/api/mappers/NoteMapper.java
@@ -31,7 +31,7 @@ public class NoteMapper extends BaseMapper {
       .text(note.getText())
       .type(note.getType())
       .createdDate(note.getCreatedDate() == null ? now : note.getCreatedDate())
-      .personId(note.getPersonId())
+      .userAuthId(note.getUserAuthId())
       .fullName(note.getFullName())
       .email(note.getEmail())
       .build();
@@ -42,7 +42,7 @@ public class NoteMapper extends BaseMapper {
       .builder()
       .id(noteEntity.getId())
       .beaconId(noteEntity.getBeaconId())
-      .personId(noteEntity.getPersonId())
+      .userAuthId(noteEntity.getUserAuthId())
       .fullName(noteEntity.getFullName())
       .email(noteEntity.getEmail())
       .text(noteEntity.getText())
@@ -61,7 +61,7 @@ public class NoteMapper extends BaseMapper {
       .text(attributes.getText())
       .type(attributes.getType())
       .createdDate(attributes.getCreatedDate())
-      .personId(attributes.getPersonId())
+      .userAuthId(attributes.getUserAuthId())
       .fullName(attributes.getFullName())
       .email(attributes.getEmail())
       .build();
@@ -77,7 +77,7 @@ public class NoteMapper extends BaseMapper {
       .text(note.getText())
       .type(note.getType())
       .createdDate(note.getCreatedDate())
-      .personId(note.getPersonId())
+      .userAuthId(note.getUserAuthId())
       .fullName(note.getFullName())
       .email(note.getEmail())
       .build();

--- a/src/main/java/uk/gov/mca/beacons/api/services/DeleteBeaconService.java
+++ b/src/main/java/uk/gov/mca/beacons/api/services/DeleteBeaconService.java
@@ -3,7 +3,6 @@ package uk.gov.mca.beacons.api.services;
 import static java.lang.String.format;
 import static java.time.LocalDateTime.now;
 
-import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,7 +38,7 @@ public class DeleteBeaconService {
   }
 
   public void delete(DeleteBeaconRequestDTO request) {
-    final User user = userGateway.getUserById(request.getActorId());
+    final User user = userGateway.getUserById(request.getUserId());
     if (user == null) throw new UserNotFoundException();
 
     final Note note = Note
@@ -47,7 +46,7 @@ public class DeleteBeaconService {
       .beaconId(request.getBeaconId())
       .email(user.getEmail())
       .fullName(user.getFullName())
-      .userAuthId(request.getActorId())
+      .userId(request.getUserId())
       .type(NoteType.RECORD_HISTORY)
       .text(format(TEMPLATE_REASON_TEXT, request.getReason()))
       .createdDate(now())

--- a/src/main/java/uk/gov/mca/beacons/api/services/DeleteBeaconService.java
+++ b/src/main/java/uk/gov/mca/beacons/api/services/DeleteBeaconService.java
@@ -47,7 +47,7 @@ public class DeleteBeaconService {
       .beaconId(request.getBeaconId())
       .email(user.getEmail())
       .fullName(user.getFullName())
-      .personId(request.getActorId())
+      .userAuthId(request.getActorId())
       .type(NoteType.RECORD_HISTORY)
       .text(format(TEMPLATE_REASON_TEXT, request.getReason()))
       .createdDate(now())

--- a/src/main/java/uk/gov/mca/beacons/api/services/GetUserService.java
+++ b/src/main/java/uk/gov/mca/beacons/api/services/GetUserService.java
@@ -1,21 +1,23 @@
 package uk.gov.mca.beacons.api.services;
 
+import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.mca.beacons.api.domain.User;
 import uk.gov.mca.beacons.api.gateways.AuthGateway;
+import uk.gov.mca.beacons.api.gateways.UserGateway;
 
 @Service
 public class GetUserService {
 
-  private final AuthGateway authGateway;
+  private final UserGateway userGateway;
 
   @Autowired
-  public GetUserService(AuthGateway authGateway) {
-    this.authGateway = authGateway;
+  public GetUserService(UserGateway userGateway) {
+    this.userGateway = userGateway;
   }
 
-  public User getUser() {
-    return authGateway.getUser();
+  public User getUser(UUID id) {
+    return userGateway.getUserById(id);
   }
 }

--- a/src/main/java/uk/gov/mca/beacons/api/services/GetUserService.java
+++ b/src/main/java/uk/gov/mca/beacons/api/services/GetUserService.java
@@ -1,0 +1,21 @@
+package uk.gov.mca.beacons.api.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.mca.beacons.api.domain.User;
+import uk.gov.mca.beacons.api.gateways.AuthGateway;
+
+@Service
+public class GetUserService {
+
+  private final AuthGateway authGateway;
+
+  @Autowired
+  public GetUserService(AuthGateway authGateway) {
+    this.authGateway = authGateway;
+  }
+
+  public User getUser() {
+    return authGateway.getUser();
+  }
+}

--- a/src/main/resources/db/migration/V1.20__Change_Note_Column_Name_PersonId.sql
+++ b/src/main/resources/db/migration/V1.20__Change_Note_Column_Name_PersonId.sql
@@ -1,0 +1,3 @@
+-- Change column name, personId to userAuthId feels better than note.note
+ALTER TABLE note
+    RENAME COLUMN person_id TO user_auth_id;

--- a/src/main/resources/db/migration/V1.20__Change_Note_Column_Name_PersonId.sql
+++ b/src/main/resources/db/migration/V1.20__Change_Note_Column_Name_PersonId.sql
@@ -1,3 +1,3 @@
 -- Change column name, personId to userAuthId feels better than note.note
 ALTER TABLE note
-    RENAME COLUMN person_id TO user_auth_id;
+    RENAME COLUMN person_id TO user_id;

--- a/src/main/resources/db/migration/V1.20__Change_Note_Column_Name_PersonId.sql
+++ b/src/main/resources/db/migration/V1.20__Change_Note_Column_Name_PersonId.sql
@@ -1,3 +1,3 @@
--- Change column name, personId to userAuthId feels better than note.note
+-- Change column name, personId to userId - less confusing as it's not the id of a Person
 ALTER TABLE note
     RENAME COLUMN person_id TO user_id;

--- a/src/test/java/uk/gov/mca/beacons/api/controllers/AccountHolderControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/controllers/AccountHolderControllerIntegrationTest.java
@@ -164,7 +164,7 @@ class AccountHolderControllerIntegrationTest {
       final var deleteBeaconRequest = DeleteBeaconRequestDTO
         .builder()
         .beaconId(UUID.fromString(beaconId))
-        .actorId(UUID.fromString(createdAccountHolderId))
+        .userId(UUID.fromString(createdAccountHolderId))
         .reason("Not used on my boat")
         .build();
 

--- a/src/test/java/uk/gov/mca/beacons/api/controllers/BeaconsControllerUnitTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/controllers/BeaconsControllerUnitTest.java
@@ -117,12 +117,12 @@ class BeaconsControllerUnitTest {
   class DeleteBeacon {
 
     private UUID beaconId;
-    private UUID actorId;
+    private UUID userId;
 
     @BeforeEach
     public void init() {
       beaconId = UUID.randomUUID();
-      actorId = UUID.randomUUID();
+      userId = UUID.randomUUID();
     }
 
     @Test
@@ -131,7 +131,7 @@ class BeaconsControllerUnitTest {
         .builder()
         .beaconId(beaconId)
         .reason("Unused on my boat anymore")
-        .actorId(actorId)
+        .userId(userId)
         .build();
 
       mockMvc
@@ -154,7 +154,7 @@ class BeaconsControllerUnitTest {
         deleteBeaconRequestValue.getReason(),
         is("Unused on my boat anymore")
       );
-      assertThat(deleteBeaconRequestValue.getActorId(), is(actorId));
+      assertThat(deleteBeaconRequestValue.getUserId(), is(userId));
     }
 
     @Test
@@ -162,7 +162,7 @@ class BeaconsControllerUnitTest {
       final var deleteBeaconRequest = DeleteBeaconRequestDTO
         .builder()
         .beaconId(beaconId)
-        .actorId(actorId)
+        .userId(userId)
         .build();
 
       mockMvc
@@ -191,7 +191,7 @@ class BeaconsControllerUnitTest {
         .builder()
         .beaconId(beaconId)
         .reason("Unused on my boat anymore")
-        .actorId(actorId)
+        .userId(userId)
         .build();
 
       mockMvc

--- a/src/test/java/uk/gov/mca/beacons/api/controllers/NoteControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/controllers/NoteControllerIntegrationTest.java
@@ -89,12 +89,12 @@ class NoteControllerIntegrationTest {
     )
       .replace("replace-with-test-beacon-id", createdBeacon.getId().toString());
 
-    final String userId = "344848b9-8a5d-4818-a57d-1815528d543e";
+    final UUID userId = UUID.fromString("344848b9-8a5d-4818-a57d-1815528d543e");
     final String fullName = "Jean ValJean";
     final String email = "24601@jail.fr";
     final User user = BackOfficeUser
       .builder()
-      .authId(userId)
+      .id(userId)
       .fullName(fullName)
       .email(email)
       .build();

--- a/src/test/java/uk/gov/mca/beacons/api/controllers/NoteControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/controllers/NoteControllerIntegrationTest.java
@@ -18,6 +18,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.reactive.function.BodyInserters;
 import uk.gov.mca.beacons.api.domain.Activity;
+import uk.gov.mca.beacons.api.domain.BackOfficeUser;
 import uk.gov.mca.beacons.api.domain.Environment;
 import uk.gov.mca.beacons.api.domain.Purpose;
 import uk.gov.mca.beacons.api.domain.User;
@@ -88,19 +89,17 @@ class NoteControllerIntegrationTest {
     )
       .replace("replace-with-test-beacon-id", createdBeacon.getId().toString());
 
-    final UUID personId = UUID.fromString(
-      "344848b9-8a5d-4818-a57d-1815528d543e"
-    );
+    final String personId = "344848b9-8a5d-4818-a57d-1815528d543e";
     final String fullName = "Jean ValJean";
     final String email = "24601@jail.fr";
-    final User user = User
+    final User user = BackOfficeUser
       .builder()
       .authId(personId)
       .fullName(fullName)
       .email(email)
       .build();
 
-    given(getUserService.getUser()).willReturn(user);
+    given(getUserService.getUser(null)).willReturn(user);
 
     var response = webTestClient
       .post()

--- a/src/test/java/uk/gov/mca/beacons/api/controllers/NoteControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/controllers/NoteControllerIntegrationTest.java
@@ -89,12 +89,12 @@ class NoteControllerIntegrationTest {
     )
       .replace("replace-with-test-beacon-id", createdBeacon.getId().toString());
 
-    final String personId = "344848b9-8a5d-4818-a57d-1815528d543e";
+    final String userAuthId = "344848b9-8a5d-4818-a57d-1815528d543e";
     final String fullName = "Jean ValJean";
     final String email = "24601@jail.fr";
     final User user = BackOfficeUser
       .builder()
-      .authId(personId)
+      .authId(userAuthId)
       .fullName(fullName)
       .email(email)
       .build();

--- a/src/test/java/uk/gov/mca/beacons/api/controllers/NoteControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/controllers/NoteControllerIntegrationTest.java
@@ -89,12 +89,12 @@ class NoteControllerIntegrationTest {
     )
       .replace("replace-with-test-beacon-id", createdBeacon.getId().toString());
 
-    final String userAuthId = "344848b9-8a5d-4818-a57d-1815528d543e";
+    final String userId = "344848b9-8a5d-4818-a57d-1815528d543e";
     final String fullName = "Jean ValJean";
     final String email = "24601@jail.fr";
     final User user = BackOfficeUser
       .builder()
-      .authId(userAuthId)
+      .authId(userId)
       .fullName(fullName)
       .email(email)
       .build();

--- a/src/test/java/uk/gov/mca/beacons/api/controllers/NoteControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/controllers/NoteControllerIntegrationTest.java
@@ -1,0 +1,119 @@
+package uk.gov.mca.beacons.api.controllers;
+
+import static org.mockito.BDDMockito.given;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.reactive.function.BodyInserters;
+import uk.gov.mca.beacons.api.domain.Activity;
+import uk.gov.mca.beacons.api.domain.Environment;
+import uk.gov.mca.beacons.api.domain.Purpose;
+import uk.gov.mca.beacons.api.domain.User;
+import uk.gov.mca.beacons.api.jpa.entities.Beacon;
+import uk.gov.mca.beacons.api.jpa.entities.BeaconUse;
+import uk.gov.mca.beacons.api.jpa.entities.Person;
+import uk.gov.mca.beacons.api.jpa.entities.Registration;
+import uk.gov.mca.beacons.api.services.CreateRegistrationService;
+import uk.gov.mca.beacons.api.services.GetUserService;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+class NoteControllerIntegrationTest {
+
+  private Beacon beacon;
+  private Beacon createdBeacon;
+  private Registration createdRegistration;
+
+  @Autowired
+  private WebTestClient webTestClient;
+
+  @Autowired
+  private CreateRegistrationService createRegistrationService;
+
+  @MockBean
+  private GetUserService getUserService;
+
+  @BeforeEach
+  void init() {
+    BeaconUse beaconUse = new BeaconUse();
+    beaconUse.setEnvironment(Environment.LAND);
+    beaconUse.setPurpose(Purpose.PLEASURE);
+    beaconUse.setActivity(Activity.CLIMBING_MOUNTAINEERING);
+    beaconUse.setMainUse(true);
+    beaconUse.setMoreDetails("I stole a loaf of bread");
+
+    Person emergencyContact = new Person();
+    Person owner = new Person();
+
+    String hexId = UUID.randomUUID().toString();
+    String manufacturer = "French";
+    String model = "Revolution";
+    String manufacturerSerialNumber = "2460124601";
+    beacon = new Beacon();
+    beacon.setHexId(hexId);
+    beacon.setManufacturer(manufacturer);
+    beacon.setModel(model);
+    beacon.setManufacturerSerialNumber(manufacturerSerialNumber);
+    beacon.setUses(List.of(beaconUse));
+    beacon.setOwner(owner);
+    beacon.setEmergencyContacts(List.of(emergencyContact));
+
+    Registration registration = new Registration();
+    registration.setBeacons(List.of(beacon));
+    createdRegistration = createRegistrationService.register(registration);
+    createdBeacon = createdRegistration.getBeacons().get(0);
+  }
+
+  @Test
+  void shouldCreateAndReturnTheCreatedNote() throws Exception {
+    final String createNoteRequest = readFile(
+      "src/test/resources/fixtures/createNoteRequest.json"
+    )
+      .replace("replace-with-test-beacon-id", createdBeacon.getId().toString());
+
+    final String createNoteResponse = readFile(
+      "src/test/resources/fixtures/createNoteResponse.json"
+    )
+      .replace("replace-with-test-beacon-id", createdBeacon.getId().toString());
+
+    final UUID personId = UUID.fromString(
+      "344848b9-8a5d-4818-a57d-1815528d543e"
+    );
+    final String fullName = "Jean ValJean";
+    final String email = "24601@jail.fr";
+    final User user = User
+      .builder()
+      .authId(personId)
+      .fullName(fullName)
+      .email(email)
+      .build();
+
+    given(getUserService.getUser()).willReturn(user);
+
+    var response = webTestClient
+      .post()
+      .uri("/note")
+      .body(BodyInserters.fromValue(createNoteRequest))
+      .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+      .exchange()
+      .expectBody();
+
+    response.json(createNoteResponse);
+  }
+
+  private String readFile(String filePath) throws IOException {
+    return new String(Files.readAllBytes(Paths.get(filePath)));
+  }
+}

--- a/src/test/java/uk/gov/mca/beacons/api/controllers/NoteControllerUnitTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/controllers/NoteControllerUnitTest.java
@@ -57,7 +57,7 @@ class NoteControllerUnitTest {
         .builder()
         .authId(UUID.randomUUID())
         .fullName("Joanna Castille")
-        .email("hello@something.com")
+        .email("my.son.sux@gmail.com")
         .build();
   }
 
@@ -69,11 +69,10 @@ class NoteControllerUnitTest {
       final WrapperDTO<NoteDTO> newNoteDTO = new WrapperDTO<>();
       final String newNoteRequest = new ObjectMapper()
         .writeValueAsString(newNoteDTO);
-      note.setPersonId(user.getAuthId());
-      note.setFullName(user.getFullName());
-      note.setEmail(user.getEmail());
+      note.setUser(user);
 
       given(noteMapper.fromDTO(newNoteDTO.getData())).willReturn(note);
+
       mvc
         .perform(
           post("/note")
@@ -109,9 +108,7 @@ class NoteControllerUnitTest {
       final WrapperDTO<NoteDTO> newNoteDTO = new WrapperDTO<>();
       final String newNoteRequest = new ObjectMapper()
         .writeValueAsString(newNoteDTO);
-      note.setPersonId(user.getAuthId());
-      note.setFullName(user.getFullName());
-      note.setEmail(user.getEmail());
+      note.setUser(user);
 
       given(noteMapper.fromDTO(newNoteDTO.getData())).willReturn(note);
 

--- a/src/test/java/uk/gov/mca/beacons/api/controllers/NoteControllerUnitTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/controllers/NoteControllerUnitTest.java
@@ -19,6 +19,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.mca.beacons.api.WebMvcTestConfiguration;
+import uk.gov.mca.beacons.api.domain.BackOfficeUser;
 import uk.gov.mca.beacons.api.domain.Note;
 import uk.gov.mca.beacons.api.domain.User;
 import uk.gov.mca.beacons.api.dto.NoteDTO;
@@ -50,14 +51,25 @@ class NoteControllerUnitTest {
   @BeforeEach
   public final void before() {
     final UUID noteId = UUID.randomUUID();
-    note = Note.builder().id(noteId).build();
+    final UUID personId = UUID.randomUUID();
+    final String fullName = "Joanna Castille";
+    final String email = "my.son.sux@gmail.com";
+
+    note =
+      Note
+        .builder()
+        .id(noteId)
+        .personId(personId)
+        .fullName(fullName)
+        .email(email)
+        .build();
 
     user =
-      User
+      BackOfficeUser
         .builder()
-        .authId(UUID.randomUUID())
-        .fullName("Joanna Castille")
-        .email("my.son.sux@gmail.com")
+        .authId(personId.toString())
+        .fullName(fullName)
+        .email(email)
         .build();
   }
 
@@ -69,7 +81,6 @@ class NoteControllerUnitTest {
       final WrapperDTO<NoteDTO> newNoteDTO = new WrapperDTO<>();
       final String newNoteRequest = new ObjectMapper()
         .writeValueAsString(newNoteDTO);
-      note.setUser(user);
 
       given(noteMapper.fromDTO(newNoteDTO.getData())).willReturn(note);
 
@@ -88,8 +99,12 @@ class NoteControllerUnitTest {
       final String newNoteRequest = new ObjectMapper()
         .writeValueAsString(newNoteDTO);
 
+      note.setPersonId(null);
+      note.setFullName(null);
+      note.setEmail(null);
+
       given(noteMapper.fromDTO(newNoteDTO.getData())).willReturn(note);
-      given(getUserService.getUser()).willReturn(user);
+      given(getUserService.getUser(null)).willReturn(user);
 
       mvc.perform(
         post("/note")
@@ -97,16 +112,15 @@ class NoteControllerUnitTest {
           .content(newNoteRequest)
       );
 
-      verify(getUserService, times(1)).getUser();
+      verify(getUserService, times(1)).getUser(null);
     }
 
     @Test
-    void shouldNotCallTheGetUserServiceIfNoteHasNoUserAttached()
+    void shouldNotCallTheGetUserServiceIfNoteHasAUserAttached()
       throws Exception {
       final WrapperDTO<NoteDTO> newNoteDTO = new WrapperDTO<>();
       final String newNoteRequest = new ObjectMapper()
         .writeValueAsString(newNoteDTO);
-      note.setUser(user);
 
       given(noteMapper.fromDTO(newNoteDTO.getData())).willReturn(note);
 
@@ -116,7 +130,7 @@ class NoteControllerUnitTest {
           .content(newNoteRequest)
       );
 
-      verify(getUserService, times(0)).getUser();
+      verify(getUserService, times(0)).getUser(null);
     }
 
     @Test
@@ -124,7 +138,6 @@ class NoteControllerUnitTest {
       final WrapperDTO<NoteDTO> newNoteDTO = new WrapperDTO<>();
       final String newNoteRequest = new ObjectMapper()
         .writeValueAsString(newNoteDTO);
-      note.setUser(user);
 
       given(noteMapper.fromDTO(newNoteDTO.getData())).willReturn(note);
 

--- a/src/test/java/uk/gov/mca/beacons/api/controllers/NoteControllerUnitTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/controllers/NoteControllerUnitTest.java
@@ -91,13 +91,11 @@ class NoteControllerUnitTest {
       given(noteMapper.fromDTO(newNoteDTO.getData())).willReturn(note);
       given(getUserService.getUser()).willReturn(user);
 
-      mvc
-        .perform(
-          post("/note")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(newNoteRequest)
-        )
-        .andExpect(status().isCreated());
+      mvc.perform(
+        post("/note")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(newNoteRequest)
+      );
 
       verify(getUserService, times(1)).getUser();
     }
@@ -112,15 +110,31 @@ class NoteControllerUnitTest {
 
       given(noteMapper.fromDTO(newNoteDTO.getData())).willReturn(note);
 
-      mvc
-        .perform(
-          post("/note")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(newNoteRequest)
-        )
-        .andExpect(status().isCreated());
+      mvc.perform(
+        post("/note")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(newNoteRequest)
+      );
 
       verify(getUserService, times(0)).getUser();
+    }
+
+    @Test
+    void shouldCallTheNoteServiceToCreateANewNote() throws Exception {
+      final WrapperDTO<NoteDTO> newNoteDTO = new WrapperDTO<>();
+      final String newNoteRequest = new ObjectMapper()
+        .writeValueAsString(newNoteDTO);
+      note.setUser(user);
+
+      given(noteMapper.fromDTO(newNoteDTO.getData())).willReturn(note);
+
+      mvc.perform(
+        post("/note")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(newNoteRequest)
+      );
+
+      verify(noteService, times(1)).create(note);
     }
   }
 }

--- a/src/test/java/uk/gov/mca/beacons/api/controllers/NoteControllerUnitTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/controllers/NoteControllerUnitTest.java
@@ -55,14 +55,7 @@ class NoteControllerUnitTest {
     final String fullName = "Joanna Castille";
     final String email = "my.son.sux@gmail.com";
 
-    note =
-      Note
-        .builder()
-        .id(noteId)
-        .userAuthId(personId)
-        .fullName(fullName)
-        .email(email)
-        .build();
+    note = Note.builder().id(noteId).build();
 
     user =
       BackOfficeUser
@@ -83,6 +76,7 @@ class NoteControllerUnitTest {
         .writeValueAsString(newNoteDTO);
 
       given(noteMapper.fromDTO(newNoteDTO.getData())).willReturn(note);
+      given(getUserService.getUser(null)).willReturn(user);
 
       mvc
         .perform(
@@ -94,14 +88,10 @@ class NoteControllerUnitTest {
     }
 
     @Test
-    void shouldCallTheGetUserServiceIfNoteHasNoUserAttached() throws Exception {
+    void shouldCallTheGetUserService() throws Exception {
       final WrapperDTO<NoteDTO> newNoteDTO = new WrapperDTO<>();
       final String newNoteRequest = new ObjectMapper()
         .writeValueAsString(newNoteDTO);
-
-      note.setUserAuthId(null);
-      note.setFullName(null);
-      note.setEmail(null);
 
       given(noteMapper.fromDTO(newNoteDTO.getData())).willReturn(note);
       given(getUserService.getUser(null)).willReturn(user);
@@ -116,30 +106,13 @@ class NoteControllerUnitTest {
     }
 
     @Test
-    void shouldNotCallTheGetUserServiceIfNoteHasAUserAttached()
-      throws Exception {
-      final WrapperDTO<NoteDTO> newNoteDTO = new WrapperDTO<>();
-      final String newNoteRequest = new ObjectMapper()
-        .writeValueAsString(newNoteDTO);
-
-      given(noteMapper.fromDTO(newNoteDTO.getData())).willReturn(note);
-
-      mvc.perform(
-        post("/note")
-          .contentType(MediaType.APPLICATION_JSON)
-          .content(newNoteRequest)
-      );
-
-      verify(getUserService, times(0)).getUser(null);
-    }
-
-    @Test
     void shouldCallTheNoteServiceToCreateANewNote() throws Exception {
       final WrapperDTO<NoteDTO> newNoteDTO = new WrapperDTO<>();
       final String newNoteRequest = new ObjectMapper()
         .writeValueAsString(newNoteDTO);
 
       given(noteMapper.fromDTO(newNoteDTO.getData())).willReturn(note);
+      given(getUserService.getUser(null)).willReturn(user);
 
       mvc.perform(
         post("/note")

--- a/src/test/java/uk/gov/mca/beacons/api/controllers/NoteControllerUnitTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/controllers/NoteControllerUnitTest.java
@@ -1,0 +1,68 @@
+package uk.gov.mca.beacons.api.controllers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.mca.beacons.api.WebMvcTestConfiguration;
+import uk.gov.mca.beacons.api.domain.Note;
+import uk.gov.mca.beacons.api.dto.NoteDTO;
+import uk.gov.mca.beacons.api.dto.WrapperDTO;
+import uk.gov.mca.beacons.api.mappers.NoteMapper;
+import uk.gov.mca.beacons.api.services.GetUserService;
+import uk.gov.mca.beacons.api.services.NoteService;
+
+@WebMvcTest(controllers = NoteController.class)
+@AutoConfigureMockMvc
+@Import(WebMvcTestConfiguration.class)
+class NoteControllerUnitTest {
+
+  private final UUID noteId = UUID.randomUUID();
+  private final Note note = new Note();
+
+  @Autowired
+  private MockMvc mvc;
+
+  @MockBean
+  private NoteService noteService;
+
+  @MockBean
+  private NoteMapper noteMapper;
+
+  @MockBean
+  private GetUserService getUserService;
+
+  @BeforeEach
+  public final void before() {
+    note.setId(noteId);
+  }
+
+  @Nested
+  class RequestCreateNote {
+
+    @Test
+    void shouldReturn201IfSuccessful() throws Exception {
+      final WrapperDTO<NoteDTO> newNoteDTO = new WrapperDTO<>();
+      final String newNoteRequest = new ObjectMapper()
+        .writeValueAsString(newNoteDTO);
+      mvc
+        .perform(
+          post("/note")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(newNoteRequest)
+        )
+        .andExpect(status().isCreated());
+    }
+  }
+}

--- a/src/test/java/uk/gov/mca/beacons/api/controllers/NoteControllerUnitTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/controllers/NoteControllerUnitTest.java
@@ -51,7 +51,7 @@ class NoteControllerUnitTest {
   @BeforeEach
   public final void before() {
     final UUID noteId = UUID.randomUUID();
-    final UUID personId = UUID.randomUUID();
+    final UUID userId = UUID.randomUUID();
     final String fullName = "Joanna Castille";
     final String email = "my.son.sux@gmail.com";
 
@@ -60,7 +60,7 @@ class NoteControllerUnitTest {
     user =
       BackOfficeUser
         .builder()
-        .authId(personId.toString())
+        .id(userId)
         .fullName(fullName)
         .email(email)
         .build();

--- a/src/test/java/uk/gov/mca/beacons/api/controllers/NoteControllerUnitTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/controllers/NoteControllerUnitTest.java
@@ -59,7 +59,7 @@ class NoteControllerUnitTest {
       Note
         .builder()
         .id(noteId)
-        .personId(personId)
+        .userAuthId(personId)
         .fullName(fullName)
         .email(email)
         .build();
@@ -99,7 +99,7 @@ class NoteControllerUnitTest {
       final String newNoteRequest = new ObjectMapper()
         .writeValueAsString(newNoteDTO);
 
-      note.setPersonId(null);
+      note.setUserAuthId(null);
       note.setFullName(null);
       note.setEmail(null);
 

--- a/src/test/java/uk/gov/mca/beacons/api/gateways/AuthGatewayImplTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/gateways/AuthGatewayImplTest.java
@@ -58,19 +58,19 @@ class AuthGatewayImplTest {
 
     @Test
     void getsUserAttributesAndCreatesUser() {
-      final String authId = "0fd158e9-d648-4b11-88d9-7bc57080aa5e";
+      final String userId = "0fd158e9-d648-4b11-88d9-7bc57080aa5e";
       final String fullName = "Marie Antoinette";
       final String email = "let.them.eat@cake.fr";
 
       final var mockPrincipal = new HashMap<String, Object>();
-      mockPrincipal.put("oid", authId.toString());
+      mockPrincipal.put("oid", userId);
       mockPrincipal.put("name", fullName);
       mockPrincipal.put("email", email);
       given(principal.getAttributes()).willReturn(mockPrincipal);
 
       User user = authGateway.getUser();
 
-      assertThat(user.getAuthId(), is(authId));
+      assertThat(user.getId(), is(UUID.fromString(userId)));
       assertThat(user.getFullName(), is(fullName));
       assertThat(user.getEmail(), is(email));
     }

--- a/src/test/java/uk/gov/mca/beacons/api/gateways/NoteGatewayImplTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/gateways/NoteGatewayImplTest.java
@@ -44,7 +44,7 @@ class NoteGatewayImplTest {
     final String text = "This beacon belongs to a cat.";
     final NoteType type = NoteType.GENERAL;
     final LocalDateTime createdDate = LocalDateTime.now();
-    final UUID personId = UUID.randomUUID();
+    final UUID userAuthId = UUID.randomUUID();
     final String fullName = "Alfred the cat";
     final String email = "alfred@cute.cat.com";
 
@@ -54,7 +54,7 @@ class NoteGatewayImplTest {
       .text(text)
       .type(type)
       .createdDate(createdDate)
-      .personId(personId)
+      .userAuthId(userAuthId)
       .fullName(fullName)
       .email(email)
       .build();
@@ -66,7 +66,7 @@ class NoteGatewayImplTest {
       .text(text)
       .type(type)
       .createdDate(createdDate)
-      .personId(personId)
+      .userAuthId(userAuthId)
       .fullName(fullName)
       .email(email)
       .build();
@@ -86,7 +86,7 @@ class NoteGatewayImplTest {
     assertThat(createdNote.getText(), is(text));
     assertThat(createdNote.getType(), is(type));
     assertThat(createdNote.getCreatedDate(), is(createdDate));
-    assertThat(createdNote.getPersonId(), is(personId));
+    assertThat(createdNote.getUserAuthId(), is(userAuthId));
     assertThat(createdNote.getFullName(), is(fullName));
     assertThat(createdNote.getEmail(), is(email));
   }

--- a/src/test/java/uk/gov/mca/beacons/api/gateways/NoteGatewayImplTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/gateways/NoteGatewayImplTest.java
@@ -100,7 +100,18 @@ class NoteGatewayImplTest {
 
   @Test
   void shouldSetCreatedDateIfNotProvided() {
-    final Note note = new Note();
+    final UUID personId = UUID.randomUUID();
+    final String fullName = "Loki the cat";
+    final String email = "loki@cute.cat.com";
+
+    final User user = User
+      .builder()
+      .authId(personId)
+      .fullName(fullName)
+      .email(email)
+      .build();
+
+    final Note note = Note.builder().user(user).build();
     final NoteEntity createdEntity = new NoteEntity();
 
     final NoteMapper noteMapper = new NoteMapper(fixedClock);

--- a/src/test/java/uk/gov/mca/beacons/api/gateways/NoteGatewayImplTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/gateways/NoteGatewayImplTest.java
@@ -44,7 +44,7 @@ class NoteGatewayImplTest {
     final String text = "This beacon belongs to a cat.";
     final NoteType type = NoteType.GENERAL;
     final LocalDateTime createdDate = LocalDateTime.now();
-    final UUID userAuthId = UUID.randomUUID();
+    final UUID userId = UUID.randomUUID();
     final String fullName = "Alfred the cat";
     final String email = "alfred@cute.cat.com";
 
@@ -54,7 +54,7 @@ class NoteGatewayImplTest {
       .text(text)
       .type(type)
       .createdDate(createdDate)
-      .userAuthId(userAuthId)
+      .userId(userId)
       .fullName(fullName)
       .email(email)
       .build();
@@ -66,7 +66,7 @@ class NoteGatewayImplTest {
       .text(text)
       .type(type)
       .createdDate(createdDate)
-      .userAuthId(userAuthId)
+      .userId(userId)
       .fullName(fullName)
       .email(email)
       .build();
@@ -86,7 +86,7 @@ class NoteGatewayImplTest {
     assertThat(createdNote.getText(), is(text));
     assertThat(createdNote.getType(), is(type));
     assertThat(createdNote.getCreatedDate(), is(createdDate));
-    assertThat(createdNote.getUserAuthId(), is(userAuthId));
+    assertThat(createdNote.getUserId(), is(userId));
     assertThat(createdNote.getFullName(), is(fullName));
     assertThat(createdNote.getEmail(), is(email));
   }

--- a/src/test/java/uk/gov/mca/beacons/api/gateways/NoteGatewayImplTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/gateways/NoteGatewayImplTest.java
@@ -93,17 +93,7 @@ class NoteGatewayImplTest {
 
   @Test
   void shouldSetCreatedDateIfNotProvided() {
-    final UUID personId = UUID.randomUUID();
-    final String fullName = "Loki the cat";
-    final String email = "loki@cute.cat.com";
-
-    final Note note = Note
-      .builder()
-      .personId(personId)
-      .fullName(fullName)
-      .email(email)
-      .build();
-
+    final Note note = new Note();
     final NoteEntity createdEntity = new NoteEntity();
     final NoteMapper noteMapper = new NoteMapper(fixedClock);
     final NoteGateway noteGateway = new NoteGatewayImpl(

--- a/src/test/java/uk/gov/mca/beacons/api/gateways/NoteGatewayImplTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/gateways/NoteGatewayImplTest.java
@@ -19,6 +19,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.mca.beacons.api.domain.Note;
 import uk.gov.mca.beacons.api.domain.NoteType;
+import uk.gov.mca.beacons.api.domain.User;
 import uk.gov.mca.beacons.api.jpa.NoteJpaRepository;
 import uk.gov.mca.beacons.api.jpa.entities.NoteEntity;
 import uk.gov.mca.beacons.api.mappers.NoteMapper;
@@ -48,15 +49,20 @@ class NoteGatewayImplTest {
     final String fullName = "Alfred the cat";
     final String email = "alfred@cute.cat.com";
 
+    final User user = User
+      .builder()
+      .authId(personId)
+      .fullName(fullName)
+      .email(email)
+      .build();
+
     final Note note = Note
       .builder()
       .beaconId(beaconId)
       .text(text)
       .type(type)
       .createdDate(createdDate)
-      .personId(personId)
-      .fullName(fullName)
-      .email(email)
+      .user(user)
       .build();
 
     final NoteEntity createdEntity = NoteEntity
@@ -76,18 +82,20 @@ class NoteGatewayImplTest {
       noteMapper,
       noteRepository
     );
+
     when(noteRepository.save(any(NoteEntity.class))).thenReturn(createdEntity);
 
     final Note createdNote = noteGateway.create(note);
+    final User noteUser = createdNote.getUser();
 
     assertThat(createdNote.getId(), is(id));
     assertThat(createdNote.getBeaconId(), is(beaconId));
     assertThat(createdNote.getText(), is(text));
     assertThat(createdNote.getType(), is(type));
     assertThat(createdNote.getCreatedDate(), is(createdDate));
-    assertThat(createdNote.getPersonId(), is(personId));
-    assertThat(createdNote.getFullName(), is(fullName));
-    assertThat(createdNote.getEmail(), is(email));
+    assertThat(noteUser.getAuthId(), is(personId));
+    assertThat(noteUser.getFullName(), is(fullName));
+    assertThat(noteUser.getEmail(), is(email));
   }
 
   @Test

--- a/src/test/java/uk/gov/mca/beacons/api/gateways/NoteGatewayImplTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/gateways/NoteGatewayImplTest.java
@@ -19,7 +19,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.mca.beacons.api.domain.Note;
 import uk.gov.mca.beacons.api.domain.NoteType;
-import uk.gov.mca.beacons.api.domain.User;
 import uk.gov.mca.beacons.api.jpa.NoteJpaRepository;
 import uk.gov.mca.beacons.api.jpa.entities.NoteEntity;
 import uk.gov.mca.beacons.api.mappers.NoteMapper;
@@ -49,20 +48,15 @@ class NoteGatewayImplTest {
     final String fullName = "Alfred the cat";
     final String email = "alfred@cute.cat.com";
 
-    final User user = User
-      .builder()
-      .authId(personId)
-      .fullName(fullName)
-      .email(email)
-      .build();
-
     final Note note = Note
       .builder()
       .beaconId(beaconId)
       .text(text)
       .type(type)
       .createdDate(createdDate)
-      .user(user)
+      .personId(personId)
+      .fullName(fullName)
+      .email(email)
       .build();
 
     final NoteEntity createdEntity = NoteEntity
@@ -86,16 +80,15 @@ class NoteGatewayImplTest {
     when(noteRepository.save(any(NoteEntity.class))).thenReturn(createdEntity);
 
     final Note createdNote = noteGateway.create(note);
-    final User noteUser = createdNote.getUser();
 
     assertThat(createdNote.getId(), is(id));
     assertThat(createdNote.getBeaconId(), is(beaconId));
     assertThat(createdNote.getText(), is(text));
     assertThat(createdNote.getType(), is(type));
     assertThat(createdNote.getCreatedDate(), is(createdDate));
-    assertThat(noteUser.getAuthId(), is(personId));
-    assertThat(noteUser.getFullName(), is(fullName));
-    assertThat(noteUser.getEmail(), is(email));
+    assertThat(createdNote.getPersonId(), is(personId));
+    assertThat(createdNote.getFullName(), is(fullName));
+    assertThat(createdNote.getEmail(), is(email));
   }
 
   @Test
@@ -104,16 +97,14 @@ class NoteGatewayImplTest {
     final String fullName = "Loki the cat";
     final String email = "loki@cute.cat.com";
 
-    final User user = User
+    final Note note = Note
       .builder()
-      .authId(personId)
+      .personId(personId)
       .fullName(fullName)
       .email(email)
       .build();
 
-    final Note note = Note.builder().user(user).build();
     final NoteEntity createdEntity = new NoteEntity();
-
     final NoteMapper noteMapper = new NoteMapper(fixedClock);
     final NoteGateway noteGateway = new NoteGatewayImpl(
       noteMapper,

--- a/src/test/java/uk/gov/mca/beacons/api/gateways/UserGatewayImplUnitTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/gateways/UserGatewayImplUnitTest.java
@@ -32,14 +32,14 @@ class UserGatewayImplUnitTest {
       .willReturn(
         AccountHolder
           .builder()
-          .authId("0fd158e9-d648-4b11-88d9-7bc57080aa5e")
+          .id(id)
           .fullName("Account Holder")
           .email("account.holder@beaconsstore.gov.uk")
           .build()
       );
 
     final var user = userGateway.getUserById(id);
-    assertThat(user.getAuthId(), is("0fd158e9-d648-4b11-88d9-7bc57080aa5e"));
+    assertThat(user.getId(), is(id));
     assertThat(user.getFullName(), is("Account Holder"));
     assertThat(user.getEmail(), is("account.holder@beaconsstore.gov.uk"));
   }
@@ -52,14 +52,14 @@ class UserGatewayImplUnitTest {
       .willReturn(
         BackOfficeUser
           .builder()
-          .authId("0fd158e9-d648-4b11-88d9-7bc57080aa5d")
+          .id(id)
           .fullName("Back Office Crew")
           .email("backoffice@mcgca.gov.uk")
           .build()
       );
 
     final var user = userGateway.getUserById(id);
-    assertThat(user.getAuthId(), is("0fd158e9-d648-4b11-88d9-7bc57080aa5d"));
+    assertThat(user.getId(), is(id));
     assertThat(user.getFullName(), is("Back Office Crew"));
     assertThat(user.getEmail(), is("backoffice@mcgca.gov.uk"));
   }

--- a/src/test/java/uk/gov/mca/beacons/api/mappers/NoteMapperTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/mappers/NoteMapperTest.java
@@ -42,7 +42,7 @@ class NoteMapperTest {
     final String text = "Beacon pancakes, making beacon pancakes";
     final NoteType type = NoteType.INCIDENT;
     final LocalDateTime createdDate = LocalDateTime.now();
-    final UUID personId = UUID.randomUUID();
+    final UUID userAuthId = UUID.randomUUID();
     final String fullName = "Jake The Dog";
     final String email = "i.love.lady@rainicorn.com";
 
@@ -54,7 +54,7 @@ class NoteMapperTest {
         .text(text)
         .type(type)
         .createdDate(createdDate)
-        .personId(personId)
+        .userAuthId(userAuthId)
         .fullName(fullName)
         .email(email)
         .build();
@@ -66,7 +66,7 @@ class NoteMapperTest {
         .text(text)
         .type(type)
         .createdDate(createdDate)
-        .personId(personId)
+        .userAuthId(userAuthId)
         .fullName(fullName)
         .email(email)
         .build();
@@ -85,7 +85,7 @@ class NoteMapperTest {
     assertThat(mappedNote.getText(), is(DTOAttributes.getText()));
     assertThat(mappedNote.getType(), is(DTOAttributes.getType()));
     assertThat(mappedNote.getCreatedDate(), is(DTOAttributes.getCreatedDate()));
-    assertThat(mappedNote.getPersonId(), is(DTOAttributes.getPersonId()));
+    assertThat(mappedNote.getUserAuthId(), is(DTOAttributes.getUserAuthId()));
     assertThat(mappedNote.getFullName(), is(DTOAttributes.getFullName()));
     assertThat(mappedNote.getEmail(), is(DTOAttributes.getEmail()));
   }
@@ -100,7 +100,7 @@ class NoteMapperTest {
     assertThat(mappedAttributes.getText(), is(note.getText()));
     assertThat(mappedAttributes.getType(), is(note.getType()));
     assertThat(mappedAttributes.getCreatedDate(), is(note.getCreatedDate()));
-    assertThat(mappedAttributes.getPersonId(), is(note.getPersonId()));
+    assertThat(mappedAttributes.getUserAuthId(), is(note.getUserAuthId()));
     assertThat(mappedAttributes.getFullName(), is(note.getFullName()));
     assertThat(mappedAttributes.getEmail(), is(note.getEmail()));
   }

--- a/src/test/java/uk/gov/mca/beacons/api/mappers/NoteMapperTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/mappers/NoteMapperTest.java
@@ -4,12 +4,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import uk.gov.mca.beacons.api.domain.Note;
 import uk.gov.mca.beacons.api.domain.NoteType;
 import uk.gov.mca.beacons.api.dto.NoteDTO;
@@ -19,12 +22,20 @@ import uk.gov.mca.beacons.api.dto.WrapperDTO;
 @TestInstance(Lifecycle.PER_CLASS)
 class NoteMapperTest {
 
+  @InjectMocks
+  private NoteMapper noteMapper;
+
+  @Mock
+  private Clock clock;
+
   private Note note;
   private NoteDTO noteDTO;
   private Attributes DTOAttributes;
 
   @BeforeAll
   public void setup() {
+    noteMapper = new NoteMapper(clock);
+
     final UUID id = UUID.randomUUID();
     final UUID beaconId = UUID.randomUUID();
     final String text = "Beacon pancakes, making beacon pancakes";
@@ -66,7 +77,7 @@ class NoteMapperTest {
 
   @Test
   void fromDTO_shouldSetAllTheFieldsOnTheNoteDTOFromTheNote() {
-    final Note mappedNote = NoteMapper.fromDTO(noteDTO);
+    final Note mappedNote = noteMapper.fromDTO(noteDTO);
 
     assertThat(mappedNote.getId(), is(noteDTO.getId()));
     assertThat(mappedNote.getBeaconId(), is(DTOAttributes.getBeaconId()));
@@ -80,7 +91,7 @@ class NoteMapperTest {
 
   @Test
   void toDTO_shouldInstantiateANoteFromTheNoteDTO() {
-    final NoteDTO mappedDTO = NoteMapper.toDTO(note);
+    final NoteDTO mappedDTO = noteMapper.toDTO(note);
     final Attributes mappedAttributes = mappedDTO.getAttributes();
 
     assertThat(mappedDTO.getId(), is(note.getId()));
@@ -95,7 +106,7 @@ class NoteMapperTest {
 
   @Test
   void toWrapperDTO_shouldConvertANoteToAWrappedDTO() {
-    final WrapperDTO<NoteDTO> wrappedNote = NoteMapper.toWrapperDTO(note);
+    final WrapperDTO<NoteDTO> wrappedNote = noteMapper.toWrapperDTO(note);
 
     assertNotNull(wrappedNote.getMeta());
     assertNotNull(wrappedNote.getData());

--- a/src/test/java/uk/gov/mca/beacons/api/mappers/NoteMapperTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/mappers/NoteMapperTest.java
@@ -29,7 +29,6 @@ class NoteMapperTest {
   @Mock
   private Clock clock;
 
-  private User user;
   private Note note;
   private NoteDTO noteDTO;
   private Attributes DTOAttributes;
@@ -47,9 +46,6 @@ class NoteMapperTest {
     final String fullName = "Jake The Dog";
     final String email = "i.love.lady@rainicorn.com";
 
-    user =
-      User.builder().authId(personId).fullName(fullName).email(email).build();
-
     note =
       Note
         .builder()
@@ -58,7 +54,9 @@ class NoteMapperTest {
         .text(text)
         .type(type)
         .createdDate(createdDate)
-        .user(user)
+        .personId(personId)
+        .fullName(fullName)
+        .email(email)
         .build();
 
     DTOAttributes =
@@ -81,32 +79,30 @@ class NoteMapperTest {
   @Test
   void fromDTO_shouldSetAllTheFieldsOnTheNoteDTOFromTheNote() {
     final Note mappedNote = noteMapper.fromDTO(noteDTO);
-    final User user = mappedNote.getUser();
 
     assertThat(mappedNote.getId(), is(noteDTO.getId()));
     assertThat(mappedNote.getBeaconId(), is(DTOAttributes.getBeaconId()));
     assertThat(mappedNote.getText(), is(DTOAttributes.getText()));
     assertThat(mappedNote.getType(), is(DTOAttributes.getType()));
     assertThat(mappedNote.getCreatedDate(), is(DTOAttributes.getCreatedDate()));
-    assertThat(user.getAuthId(), is(DTOAttributes.getPersonId()));
-    assertThat(user.getFullName(), is(DTOAttributes.getFullName()));
-    assertThat(user.getEmail(), is(DTOAttributes.getEmail()));
+    assertThat(mappedNote.getPersonId(), is(DTOAttributes.getPersonId()));
+    assertThat(mappedNote.getFullName(), is(DTOAttributes.getFullName()));
+    assertThat(mappedNote.getEmail(), is(DTOAttributes.getEmail()));
   }
 
   @Test
   void toDTO_shouldInstantiateANoteFromTheNoteDTO() {
     final NoteDTO mappedDTO = noteMapper.toDTO(note);
     final Attributes mappedAttributes = mappedDTO.getAttributes();
-    final User user = note.getUser();
 
     assertThat(mappedDTO.getId(), is(note.getId()));
     assertThat(mappedAttributes.getBeaconId(), is(note.getBeaconId()));
     assertThat(mappedAttributes.getText(), is(note.getText()));
     assertThat(mappedAttributes.getType(), is(note.getType()));
     assertThat(mappedAttributes.getCreatedDate(), is(note.getCreatedDate()));
-    assertThat(mappedAttributes.getPersonId(), is(user.getAuthId()));
-    assertThat(mappedAttributes.getFullName(), is(user.getFullName()));
-    assertThat(mappedAttributes.getEmail(), is(user.getEmail()));
+    assertThat(mappedAttributes.getPersonId(), is(note.getPersonId()));
+    assertThat(mappedAttributes.getFullName(), is(note.getFullName()));
+    assertThat(mappedAttributes.getEmail(), is(note.getEmail()));
   }
 
   @Test

--- a/src/test/java/uk/gov/mca/beacons/api/mappers/NoteMapperTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/mappers/NoteMapperTest.java
@@ -7,19 +7,19 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.UUID;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.mca.beacons.api.domain.Note;
 import uk.gov.mca.beacons.api.domain.NoteType;
 import uk.gov.mca.beacons.api.dto.NoteDTO;
 import uk.gov.mca.beacons.api.dto.NoteDTO.Attributes;
 import uk.gov.mca.beacons.api.dto.WrapperDTO;
 
-@TestInstance(Lifecycle.PER_CLASS)
+@ExtendWith(MockitoExtension.class)
 class NoteMapperTest {
 
   @InjectMocks
@@ -32,10 +32,8 @@ class NoteMapperTest {
   private NoteDTO noteDTO;
   private Attributes DTOAttributes;
 
-  @BeforeAll
+  @BeforeEach
   public void setup() {
-    noteMapper = new NoteMapper(clock);
-
     final UUID id = UUID.randomUUID();
     final UUID beaconId = UUID.randomUUID();
     final String text = "Beacon pancakes, making beacon pancakes";

--- a/src/test/java/uk/gov/mca/beacons/api/mappers/NoteMapperTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/mappers/NoteMapperTest.java
@@ -15,6 +15,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import uk.gov.mca.beacons.api.domain.Note;
 import uk.gov.mca.beacons.api.domain.NoteType;
+import uk.gov.mca.beacons.api.domain.User;
 import uk.gov.mca.beacons.api.dto.NoteDTO;
 import uk.gov.mca.beacons.api.dto.NoteDTO.Attributes;
 import uk.gov.mca.beacons.api.dto.WrapperDTO;
@@ -28,6 +29,7 @@ class NoteMapperTest {
   @Mock
   private Clock clock;
 
+  private User user;
   private Note note;
   private NoteDTO noteDTO;
   private Attributes DTOAttributes;
@@ -45,6 +47,9 @@ class NoteMapperTest {
     final String fullName = "Jake The Dog";
     final String email = "i.love.lady@rainicorn.com";
 
+    user =
+      User.builder().authId(personId).fullName(fullName).email(email).build();
+
     note =
       Note
         .builder()
@@ -53,9 +58,7 @@ class NoteMapperTest {
         .text(text)
         .type(type)
         .createdDate(createdDate)
-        .personId(personId)
-        .fullName(fullName)
-        .email(email)
+        .user(user)
         .build();
 
     DTOAttributes =
@@ -78,30 +81,32 @@ class NoteMapperTest {
   @Test
   void fromDTO_shouldSetAllTheFieldsOnTheNoteDTOFromTheNote() {
     final Note mappedNote = noteMapper.fromDTO(noteDTO);
+    final User user = mappedNote.getUser();
 
     assertThat(mappedNote.getId(), is(noteDTO.getId()));
     assertThat(mappedNote.getBeaconId(), is(DTOAttributes.getBeaconId()));
     assertThat(mappedNote.getText(), is(DTOAttributes.getText()));
     assertThat(mappedNote.getType(), is(DTOAttributes.getType()));
     assertThat(mappedNote.getCreatedDate(), is(DTOAttributes.getCreatedDate()));
-    assertThat(mappedNote.getPersonId(), is(DTOAttributes.getPersonId()));
-    assertThat(mappedNote.getFullName(), is(DTOAttributes.getFullName()));
-    assertThat(mappedNote.getEmail(), is(DTOAttributes.getEmail()));
+    assertThat(user.getAuthId(), is(DTOAttributes.getPersonId()));
+    assertThat(user.getFullName(), is(DTOAttributes.getFullName()));
+    assertThat(user.getEmail(), is(DTOAttributes.getEmail()));
   }
 
   @Test
   void toDTO_shouldInstantiateANoteFromTheNoteDTO() {
     final NoteDTO mappedDTO = noteMapper.toDTO(note);
     final Attributes mappedAttributes = mappedDTO.getAttributes();
+    final User user = note.getUser();
 
     assertThat(mappedDTO.getId(), is(note.getId()));
     assertThat(mappedAttributes.getBeaconId(), is(note.getBeaconId()));
     assertThat(mappedAttributes.getText(), is(note.getText()));
     assertThat(mappedAttributes.getType(), is(note.getType()));
     assertThat(mappedAttributes.getCreatedDate(), is(note.getCreatedDate()));
-    assertThat(mappedAttributes.getPersonId(), is(note.getPersonId()));
-    assertThat(mappedAttributes.getFullName(), is(note.getFullName()));
-    assertThat(mappedAttributes.getEmail(), is(note.getEmail()));
+    assertThat(mappedAttributes.getPersonId(), is(user.getAuthId()));
+    assertThat(mappedAttributes.getFullName(), is(user.getFullName()));
+    assertThat(mappedAttributes.getEmail(), is(user.getEmail()));
   }
 
   @Test

--- a/src/test/java/uk/gov/mca/beacons/api/mappers/NoteMapperTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/mappers/NoteMapperTest.java
@@ -39,7 +39,7 @@ class NoteMapperTest {
     final String text = "Beacon pancakes, making beacon pancakes";
     final NoteType type = NoteType.INCIDENT;
     final LocalDateTime createdDate = LocalDateTime.now();
-    final UUID userAuthId = UUID.randomUUID();
+    final UUID userId = UUID.randomUUID();
     final String fullName = "Jake The Dog";
     final String email = "i.love.lady@rainicorn.com";
 
@@ -51,7 +51,7 @@ class NoteMapperTest {
         .text(text)
         .type(type)
         .createdDate(createdDate)
-        .userId(userAuthId)
+        .userId(userId)
         .fullName(fullName)
         .email(email)
         .build();
@@ -63,7 +63,7 @@ class NoteMapperTest {
         .text(text)
         .type(type)
         .createdDate(createdDate)
-        .userId(userAuthId)
+        .userId(userId)
         .fullName(fullName)
         .email(email)
         .build();

--- a/src/test/java/uk/gov/mca/beacons/api/mappers/NoteMapperTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/mappers/NoteMapperTest.java
@@ -1,0 +1,104 @@
+package uk.gov.mca.beacons.api.mappers;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import uk.gov.mca.beacons.api.domain.Note;
+import uk.gov.mca.beacons.api.domain.NoteType;
+import uk.gov.mca.beacons.api.dto.NoteDTO;
+import uk.gov.mca.beacons.api.dto.NoteDTO.Attributes;
+import uk.gov.mca.beacons.api.dto.WrapperDTO;
+
+@TestInstance(Lifecycle.PER_CLASS)
+class NoteMapperTest {
+
+  private Note note;
+  private NoteDTO noteDTO;
+  private Attributes DTOAttributes;
+
+  @BeforeAll
+  public void setup() {
+    final UUID id = UUID.randomUUID();
+    final UUID beaconId = UUID.randomUUID();
+    final String text = "Beacon pancakes, making beacon pancakes";
+    final NoteType type = NoteType.INCIDENT;
+    final LocalDateTime createdDate = LocalDateTime.now();
+    final UUID personId = UUID.randomUUID();
+    final String fullName = "Jake The Dog";
+    final String email = "i.love.lady@rainicorn.com";
+
+    note =
+      Note
+        .builder()
+        .id(id)
+        .beaconId(beaconId)
+        .text(text)
+        .type(type)
+        .createdDate(createdDate)
+        .personId(personId)
+        .fullName(fullName)
+        .email(email)
+        .build();
+
+    DTOAttributes =
+      Attributes
+        .builder()
+        .beaconId(beaconId)
+        .text(text)
+        .type(type)
+        .createdDate(createdDate)
+        .personId(personId)
+        .fullName(fullName)
+        .email(email)
+        .build();
+
+    noteDTO = new NoteDTO();
+    noteDTO.setId(id);
+    noteDTO.setAttributes(DTOAttributes);
+  }
+
+  @Test
+  void fromDTO_shouldSetAllTheFieldsOnTheNoteDTOFromTheNote() {
+    final Note mappedNote = NoteMapper.fromDTO(noteDTO);
+
+    assertThat(mappedNote.getId(), is(noteDTO.getId()));
+    assertThat(mappedNote.getBeaconId(), is(DTOAttributes.getBeaconId()));
+    assertThat(mappedNote.getText(), is(DTOAttributes.getText()));
+    assertThat(mappedNote.getType(), is(DTOAttributes.getType()));
+    assertThat(mappedNote.getCreatedDate(), is(DTOAttributes.getCreatedDate()));
+    assertThat(mappedNote.getPersonId(), is(DTOAttributes.getPersonId()));
+    assertThat(mappedNote.getFullName(), is(DTOAttributes.getFullName()));
+    assertThat(mappedNote.getEmail(), is(DTOAttributes.getEmail()));
+  }
+
+  @Test
+  void toDTO_shouldInstantiateANoteFromTheNoteDTO() {
+    final NoteDTO mappedDTO = NoteMapper.toDTO(note);
+    final Attributes mappedAttributes = mappedDTO.getAttributes();
+
+    assertThat(mappedDTO.getId(), is(note.getId()));
+    assertThat(mappedAttributes.getBeaconId(), is(note.getBeaconId()));
+    assertThat(mappedAttributes.getText(), is(note.getText()));
+    assertThat(mappedAttributes.getType(), is(note.getType()));
+    assertThat(mappedAttributes.getCreatedDate(), is(note.getCreatedDate()));
+    assertThat(mappedAttributes.getPersonId(), is(note.getPersonId()));
+    assertThat(mappedAttributes.getFullName(), is(note.getFullName()));
+    assertThat(mappedAttributes.getEmail(), is(note.getEmail()));
+  }
+
+  @Test
+  void toWrapperDTO_shouldConvertANoteToAWrappedDTO() {
+    final WrapperDTO<NoteDTO> wrappedNote = NoteMapper.toWrapperDTO(note);
+
+    assertNotNull(wrappedNote.getMeta());
+    assertNotNull(wrappedNote.getData());
+    assertNotNull(wrappedNote.getIncluded());
+  }
+}

--- a/src/test/java/uk/gov/mca/beacons/api/mappers/NoteMapperTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/mappers/NoteMapperTest.java
@@ -15,7 +15,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import uk.gov.mca.beacons.api.domain.Note;
 import uk.gov.mca.beacons.api.domain.NoteType;
-import uk.gov.mca.beacons.api.domain.User;
 import uk.gov.mca.beacons.api.dto.NoteDTO;
 import uk.gov.mca.beacons.api.dto.NoteDTO.Attributes;
 import uk.gov.mca.beacons.api.dto.WrapperDTO;
@@ -54,7 +53,7 @@ class NoteMapperTest {
         .text(text)
         .type(type)
         .createdDate(createdDate)
-        .userAuthId(userAuthId)
+        .userId(userAuthId)
         .fullName(fullName)
         .email(email)
         .build();
@@ -66,7 +65,7 @@ class NoteMapperTest {
         .text(text)
         .type(type)
         .createdDate(createdDate)
-        .userAuthId(userAuthId)
+        .userId(userAuthId)
         .fullName(fullName)
         .email(email)
         .build();
@@ -85,7 +84,7 @@ class NoteMapperTest {
     assertThat(mappedNote.getText(), is(DTOAttributes.getText()));
     assertThat(mappedNote.getType(), is(DTOAttributes.getType()));
     assertThat(mappedNote.getCreatedDate(), is(DTOAttributes.getCreatedDate()));
-    assertThat(mappedNote.getUserAuthId(), is(DTOAttributes.getUserAuthId()));
+    assertThat(mappedNote.getUserId(), is(DTOAttributes.getUserId()));
     assertThat(mappedNote.getFullName(), is(DTOAttributes.getFullName()));
     assertThat(mappedNote.getEmail(), is(DTOAttributes.getEmail()));
   }
@@ -100,7 +99,7 @@ class NoteMapperTest {
     assertThat(mappedAttributes.getText(), is(note.getText()));
     assertThat(mappedAttributes.getType(), is(note.getType()));
     assertThat(mappedAttributes.getCreatedDate(), is(note.getCreatedDate()));
-    assertThat(mappedAttributes.getUserAuthId(), is(note.getUserAuthId()));
+    assertThat(mappedAttributes.getUserId(), is(note.getUserId()));
     assertThat(mappedAttributes.getFullName(), is(note.getFullName()));
     assertThat(mappedAttributes.getEmail(), is(note.getEmail()));
   }

--- a/src/test/java/uk/gov/mca/beacons/api/services/DeleteBeaconServiceUnitTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/services/DeleteBeaconServiceUnitTest.java
@@ -50,7 +50,7 @@ class DeleteBeaconServiceUnitTest {
     final var request = DeleteBeaconRequestDTO
       .builder()
       .beaconId(UUID.randomUUID())
-      .actorId(accountHolderId)
+      .userId(accountHolderId)
       .reason("Unused on my boat anymore")
       .build();
     given(userGateway.getUserById(accountHolderId))
@@ -67,7 +67,7 @@ class DeleteBeaconServiceUnitTest {
     final var request = DeleteBeaconRequestDTO
       .builder()
       .beaconId(UUID.randomUUID())
-      .actorId(accountHolderId)
+      .userId(accountHolderId)
       .reason("Unused on my boat anymore")
       .build();
     given(userGateway.getUserById(accountHolderId)).willReturn(null);
@@ -89,7 +89,7 @@ class DeleteBeaconServiceUnitTest {
     final var request = DeleteBeaconRequestDTO
       .builder()
       .beaconId(beaconId)
-      .actorId(accountHolderId)
+      .userId(accountHolderId)
       .reason("Unused on my boat anymore")
       .build();
     final var accountHolder = AccountHolder
@@ -106,7 +106,7 @@ class DeleteBeaconServiceUnitTest {
     assertThat(note.getBeaconId(), is(beaconId));
     assertThat(note.getEmail(), is("beacons@beacons.com"));
     assertThat(note.getFullName(), is("Beacons R Us"));
-    assertThat(note.getUserAuthId(), is(accountHolderId));
+    assertThat(note.getUserId(), is(accountHolderId));
     assertThat(note.getType(), is(NoteType.RECORD_HISTORY));
     assertThat(
       note.getText(),

--- a/src/test/java/uk/gov/mca/beacons/api/services/DeleteBeaconServiceUnitTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/services/DeleteBeaconServiceUnitTest.java
@@ -106,7 +106,7 @@ class DeleteBeaconServiceUnitTest {
     assertThat(note.getBeaconId(), is(beaconId));
     assertThat(note.getEmail(), is("beacons@beacons.com"));
     assertThat(note.getFullName(), is("Beacons R Us"));
-    assertThat(note.getPersonId(), is(accountHolderId));
+    assertThat(note.getUserAuthId(), is(accountHolderId));
     assertThat(note.getType(), is(NoteType.RECORD_HISTORY));
     assertThat(
       note.getText(),

--- a/src/test/java/uk/gov/mca/beacons/api/services/GetUserServiceTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/services/GetUserServiceTest.java
@@ -10,8 +10,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.mca.beacons.api.domain.User;
-import uk.gov.mca.beacons.api.gateways.AuthGateway;
+import uk.gov.mca.beacons.api.domain.BackOfficeUser;
+import uk.gov.mca.beacons.api.gateways.UserGateway;
 
 @ExtendWith(MockitoExtension.class)
 class GetUserServiceTest {
@@ -20,22 +20,22 @@ class GetUserServiceTest {
   private GetUserService getUserService;
 
   @Mock
-  private AuthGateway mockAuthGateway;
+  private UserGateway userGateway;
 
   @Test
   void shouldReturnTheCurrentUser() {
-    final UUID authId = UUID.randomUUID();
+    final String authId = UUID.randomUUID().toString();
     final String name = "Cher Horowitz";
     final String email = "this.is@an.alaia";
-    final User user = User
+    final BackOfficeUser user = BackOfficeUser
       .builder()
       .authId(authId)
       .fullName(name)
       .email(email)
       .build();
 
-    given(mockAuthGateway.getUser()).willReturn(user);
+    given(userGateway.getUserById(null)).willReturn(user);
 
-    assertThat(getUserService.getUser(), is(user));
+    assertThat(getUserService.getUser(null), is(user));
   }
 }

--- a/src/test/java/uk/gov/mca/beacons/api/services/GetUserServiceTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/services/GetUserServiceTest.java
@@ -24,12 +24,12 @@ class GetUserServiceTest {
 
   @Test
   void shouldReturnTheCurrentUser() {
-    final String authId = UUID.randomUUID().toString();
+    final UUID userId = UUID.randomUUID();
     final String name = "Cher Horowitz";
     final String email = "this.is@an.alaia";
     final BackOfficeUser user = BackOfficeUser
       .builder()
-      .authId(authId)
+      .id(userId)
       .fullName(name)
       .email(email)
       .build();

--- a/src/test/java/uk/gov/mca/beacons/api/services/GetUserServiceTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/services/GetUserServiceTest.java
@@ -1,0 +1,41 @@
+package uk.gov.mca.beacons.api.services;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.BDDMockito.given;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.mca.beacons.api.domain.User;
+import uk.gov.mca.beacons.api.gateways.AuthGateway;
+
+@ExtendWith(MockitoExtension.class)
+class GetUserServiceTest {
+
+  @InjectMocks
+  private GetUserService getUserService;
+
+  @Mock
+  private AuthGateway mockAuthGateway;
+
+  @Test
+  void shouldReturnTheCurrentUser() {
+    final UUID authId = UUID.randomUUID();
+    final String name = "Cher Horowitz";
+    final String email = "this.is@an.alaia";
+    final User user = User
+      .builder()
+      .authId(authId)
+      .fullName(name)
+      .email(email)
+      .build();
+
+    given(mockAuthGateway.getUser()).willReturn(user);
+
+    assertThat(getUserService.getUser(), is(user));
+  }
+}

--- a/src/test/resources/fixtures/createNoteRequest.json
+++ b/src/test/resources/fixtures/createNoteRequest.json
@@ -5,9 +5,9 @@
     "type": "note",
     "relationships": {},
     "attributes": {
-      "beaconId": "1234",
+      "beaconId": "replace-with-test-beacon-id",
       "text": "That's a great beacon right there",
-      "type": "General"
+      "type": "GENERAL"
     }
   }
 }

--- a/src/test/resources/fixtures/createNoteRequest.json
+++ b/src/test/resources/fixtures/createNoteRequest.json
@@ -1,0 +1,13 @@
+{
+  "meta": {},
+  "included": [],
+  "data": {
+    "type": "note",
+    "relationships": {},
+    "attributes": {
+      "beaconId": "1234",
+      "text": "That's a great beacon right there",
+      "type": "General"
+    }
+  }
+}

--- a/src/test/resources/fixtures/createNoteResponse.json
+++ b/src/test/resources/fixtures/createNoteResponse.json
@@ -6,7 +6,7 @@
       "beaconId": "replace-with-test-beacon-id",
       "text": "That's a great beacon right there",
       "type": "GENERAL",
-      "userAuthId": "344848b9-8a5d-4818-a57d-1815528d543e",
+      "userId": "344848b9-8a5d-4818-a57d-1815528d543e",
       "fullName": "Jean ValJean",
       "email": "24601@jail.fr"
     },

--- a/src/test/resources/fixtures/createNoteResponse.json
+++ b/src/test/resources/fixtures/createNoteResponse.json
@@ -6,7 +6,7 @@
       "beaconId": "replace-with-test-beacon-id",
       "text": "That's a great beacon right there",
       "type": "GENERAL",
-      "personId": "344848b9-8a5d-4818-a57d-1815528d543e",
+      "userAuthId": "344848b9-8a5d-4818-a57d-1815528d543e",
       "fullName": "Jean ValJean",
       "email": "24601@jail.fr"
     },

--- a/src/test/resources/fixtures/createNoteResponse.json
+++ b/src/test/resources/fixtures/createNoteResponse.json
@@ -1,0 +1,16 @@
+{
+  "meta": {},
+  "data": {
+    "type": "note",
+    "attributes": {
+      "beaconId": "replace-with-test-beacon-id",
+      "text": "That's a great beacon right there",
+      "type": "GENERAL",
+      "personId": "344848b9-8a5d-4818-a57d-1815528d543e",
+      "fullName": "Jean ValJean",
+      "email": "24601@jail.fr"
+    },
+    "relationships": {}
+  },
+  "included": []
+}


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Last pieces for a `create note` endpoint

This one is a bit of a big boi - apologies 😞 - looking at the commits might be a good way to understand what I was doing.
<img src="https://media.giphy.com/media/Zu6AATBpCeUzm/giphy.gif"></img>

## Changes in this pull request

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
- Add a `getUserService` that uses the `userGateway` to get the user from `AccountHolder` table or out of Spring context (back office users)
- Add `NoteController` with `POST` endpoint for createing a note 🎉 
   - It checks to see if a `user` is on the `Note` - if there isn't one, it gets the user
   - This is to be ready for the notes being migrated  from the old DB
   - Let me know if it could be neater or if it doesn't make sense!
- Add a `NoteDTO` object
   - Add mapping methods for this in `NoteMapper`
   - Make `NoteMapper` methods non-static, to make it easier to mock in tests

- Update `Note` domain to have a field `user` instead of the individual (`personId`, `fullName`, `email`) fields

   
- Add relevant tests
      

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
- `personId` and `authId` get turned into one another a few times
    - `personId` on a note is the `authId` of the user who made the note
    - Does it make sense how it is?
    - Or is there a way to make it clearer
## Link to Trello card
https://trello.com/c/S2nXSR2x/675-api-back-office-users-need-ability-to-add-incident-notes-to-a-beacon-record

