### PR TITLE
Alter column type from timestamp to timestamp with time zone in all tables.

### DIFF
--- a/src/main/resources/db/migration/V1.30__Change_Timestamp_To_Timestamp_With_Timezone.sql
+++ b/src/main/resources/db/migration/V1.30__Change_Timestamp_To_Timestamp_With_Timezone.sql
@@ -1,0 +1,44 @@
+-- Change all timestamp types to timestamp with time zone
+-- This should fix issues in the back office application where the time appears
+-- to off by one hour
+
+-- Drop beacon_search_mat otherwise we can't change columns referenced in view.
+DROP MATERIALIZED VIEW beacon_search_mat;
+
+ALTER TABLE beacon
+    ALTER COLUMN created_date TYPE timestamp with time zone,
+    ALTER COLUMN last_modified_date TYPE timestamp with time zone;
+    
+ALTER TABLE beacon_use
+    ALTER COLUMN created_date TYPE timestamp with time zone;
+
+ALTER TABLE legacy_beacon
+    ALTER COLUMN created_date TYPE timestamp with time zone,
+    ALTER COLUMN last_modified_date TYPE timestamp with time zone;
+
+ALTER TABLE note
+    ALTER COLUMN created_date TYPE timestamp with time zone;
+
+ALTER TABLE person
+    ALTER COLUMN created_date TYPE timestamp with time zone,
+    ALTER COLUMN last_modified_date TYPE timestamp with time zone;
+
+-- Recreate beacon_search_mat from migration V1.28
+CREATE MATERIALIZED VIEW IF NOT EXISTS beacon_search_mat AS
+    SELECT id,
+           last_modified_date,
+           beacon_status,
+           hex_id,
+           (SELECT full_name FROM person WHERE person.person_type = 'OWNER' AND person.beacon_id = beacon.id) AS owner_name,
+           (SELECT string_agg(activity, ', ') FROM beacon_use WHERE beacon_use.beacon_id = beacon.id) AS use_activities
+    FROM beacon
+        UNION
+    SELECT id,
+           last_modified_date,
+           beacon_status,
+           hex_id,
+           data->'owner'->>'ownerName' as owner_name,
+           (SELECT string_agg(uses->>'useType', ', ') FROM legacy_beacon AS lb, LATERAL jsonb_array_elements(data->'uses') AS uses WHERE lb.id = legacy_beacon.id GROUP BY id) AS use_activities
+    FROM legacy_beacon;
+
+CREATE UNIQUE INDEX IF NOT EXISTS beacon_search_mat_id ON beacon_search_mat(id);


### PR DESCRIPTION

## Changes in this pull request

Added migration V1.30 which alters all columns with type `timestamp` to  type `timestamp with time zone`.  Running this migration on `timestamp` fields appends the timezone information (found by running `SHOW timezone`) from the database to the `timestamp`. 
For example if the timezone of the database is UTC+0 then `2021-08-23 10:09:22.966006` becomes `2021-08-23 10:09:22.966006+00` or if the timezone is UTC+5 then  `2021-08-23 10:09:22.966006` becomes `2021-08-23 10:09:22.966006+05`

## Link to Trello card

https://trello.com/c/UQNMUqVN/946-bug-last-modified-date-on-backoffice-out-by-an-hour

