### PR TITLE
added delete beacon owner, emergency contacts & use

### DIFF
--- a/src/main/java/uk/gov/mca/beacons/api/services/DeleteBeaconService.java
+++ b/src/main/java/uk/gov/mca/beacons/api/services/DeleteBeaconService.java
@@ -3,6 +3,7 @@ package uk.gov.mca.beacons.api.services;
 import static java.lang.String.format;
 import static java.time.LocalDateTime.now;
 
+import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -49,6 +50,22 @@ public class DeleteBeaconService {
     this.useGateway = useGateway;
   }
 
+  public void deleteOwnerByBeaconId(UUID beaconIdToBeDeleted) {
+    ownerGateway.deleteByBeaconId(beaconIdToBeDeleted);
+  }
+
+  public void deleteEmergencyContactByBeaconId(UUID beaconIdToBeDeleted) {
+    emergencyContactGateway.deleteAllByBeaconId(beaconIdToBeDeleted);
+  }
+
+  public void deleteUseByBeaconId(UUID beaconIdToBeDeleted) {
+    useGateway.deleteAllByBeaconId(beaconIdToBeDeleted);
+  }
+
+  public void deleteBeaconByBeaconId(UUID beaconIdToBeDeleted) {
+    beaconGateway.delete(beaconIdToBeDeleted);
+  }
+
   public void delete(DeleteBeaconRequestDTO request) {
     final User user = userGateway.getUserById(request.getUserId());
     if (user == null) throw new UserNotFoundException();
@@ -67,16 +84,12 @@ public class DeleteBeaconService {
       .build();
     noteGateway.create(note);
 
-    // delete beacon owner
-    ownerGateway.deleteByBeaconId(beaconIdToBeDeleted);
+    deleteOwnerByBeaconId(beaconIdToBeDeleted);
 
-    // delete emergency contacts
-    emergencyContactGateway.deleteAllByBeaconId(beaconIdToBeDeleted);
+    deleteEmergencyContactByBeaconId(beaconIdToBeDeleted);
 
-    // delete beacon use
-    useGateway.deleteAllByBeaconId(beaconIdToBeDeleted);
+    deleteUseByBeaconId(beaconIdToBeDeleted);
 
-    // delete beacon entity
-    beaconGateway.delete(beaconIdToBeDeleted);
+    deleteBeaconByBeaconId(beaconIdToBeDeleted);
   }
 }

--- a/src/main/java/uk/gov/mca/beacons/api/services/DeleteBeaconService.java
+++ b/src/main/java/uk/gov/mca/beacons/api/services/DeleteBeaconService.java
@@ -57,7 +57,7 @@ public class DeleteBeaconService {
 
     final Note note = Note
       .builder()
-      .beaconId(request.getBeaconId())
+      .beaconId(beaconIdToBeDeleted)
       .email(user.getEmail())
       .fullName(user.getFullName())
       .userId(request.getUserId())

--- a/src/main/java/uk/gov/mca/beacons/api/services/DeleteBeaconService.java
+++ b/src/main/java/uk/gov/mca/beacons/api/services/DeleteBeaconService.java
@@ -75,8 +75,6 @@ public class DeleteBeaconService {
     final Note note = Note
       .builder()
       .beaconId(beaconIdToBeDeleted)
-      .email(user.getEmail())
-      .fullName(user.getFullName())
       .userId(request.getUserId())
       .type(NoteType.RECORD_HISTORY)
       .text(format(TEMPLATE_REASON_TEXT, request.getReason()))

--- a/src/test/java/uk/gov/mca/beacons/api/services/DeleteBeaconServiceUnitTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/services/DeleteBeaconServiceUnitTest.java
@@ -2,6 +2,7 @@ package uk.gov.mca.beacons.api.services;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -115,8 +116,8 @@ class DeleteBeaconServiceUnitTest {
     verify(noteGateway).create(noteCaptor.capture());
     final var note = noteCaptor.getValue();
     assertThat(note.getBeaconId(), is(beaconId));
-    assertThat(note.getEmail(), is("beacons@beacons.com"));
-    assertThat(note.getFullName(), is("Beacons R Us"));
+    assertThat(note.getEmail(), is(nullValue()));
+    assertThat(note.getFullName(), is(nullValue()));
     assertThat(note.getUserId(), is(accountHolderId));
     assertThat(note.getType(), is(NoteType.RECORD_HISTORY));
     assertThat(

--- a/src/test/java/uk/gov/mca/beacons/api/services/DeleteBeaconServiceUnitTest.java
+++ b/src/test/java/uk/gov/mca/beacons/api/services/DeleteBeaconServiceUnitTest.java
@@ -22,9 +22,7 @@ import uk.gov.mca.beacons.api.domain.Note;
 import uk.gov.mca.beacons.api.domain.NoteType;
 import uk.gov.mca.beacons.api.dto.DeleteBeaconRequestDTO;
 import uk.gov.mca.beacons.api.exceptions.UserNotFoundException;
-import uk.gov.mca.beacons.api.gateways.BeaconGateway;
-import uk.gov.mca.beacons.api.gateways.NoteGateway;
-import uk.gov.mca.beacons.api.gateways.UserGateway;
+import uk.gov.mca.beacons.api.gateways.*;
 
 @ExtendWith(MockitoExtension.class)
 class DeleteBeaconServiceUnitTest {
@@ -40,6 +38,15 @@ class DeleteBeaconServiceUnitTest {
 
   @Mock
   private NoteGateway noteGateway;
+
+  @Mock
+  private OwnerGateway ownerGateway;
+
+  @Mock
+  private UseGateway useGateway;
+
+  @Mock
+  private EmergencyContactGateway emergencyContactGateway;
 
   @Captor
   private ArgumentCaptor<Note> noteCaptor;
@@ -58,6 +65,10 @@ class DeleteBeaconServiceUnitTest {
 
     deleteBeaconService.delete(request);
 
+    verify(ownerGateway, times(1)).deleteByBeaconId(request.getBeaconId());
+    verify(emergencyContactGateway, times(1))
+      .deleteAllByBeaconId(request.getBeaconId());
+    verify(useGateway, times(1)).deleteAllByBeaconId(request.getBeaconId());
     verify(beaconGateway, times(1)).delete(request.getBeaconId());
   }
 


### PR DESCRIPTION
## Context
As a beacon owner, when I delete my beacon, I want to have all associations (beacon owner, emergency contact(s) and the beacon use) between myself and the beacon to be removed. 

## Changes in this pull request
Called delete methods on owner, emergency contact and use gateways on the delete method in the delete beacon service class.

## Guidance to review
Data for beacon owner, emergency contact(s) and beacon use associated with the beacon id to be deleted should be themselves deleted from the database when the user requests to delete their beacon.

## Link to Trello card
Beacon owner: https://trello.com/c/TmCuqfoF/994-deleting-a-beacon-fully-deletes-owner
Beacon emergency contact(s): https://trello.com/c/db5N2T1y/995-deleting-a-beacon-fully-deletes-emergency-contacts
Beacon use: https://trello.com/c/06VriSQf/993-deleting-a-beacon-fully-deletes-use
