### PR TITLE
Jackson allow JsonIgnoreProperties where properties are unknown

### DIFF
--- a/src/main/java/uk/gov/mca/beacons/api/legacybeacon/domain/LegacyBeaconDetails.java
+++ b/src/main/java/uk/gov/mca/beacons/api/legacybeacon/domain/LegacyBeaconDetails.java
@@ -1,5 +1,6 @@
 package uk.gov.mca.beacons.api.legacybeacon.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.io.Serializable;
 import javax.validation.constraints.NotBlank;
 import lombok.*;
@@ -10,6 +11,7 @@ import uk.gov.mca.beacons.api.shared.domain.base.ValueObject;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class LegacyBeaconDetails implements ValueObject, Serializable {
 
   private String note;

--- a/src/main/java/uk/gov/mca/beacons/api/legacybeacon/domain/LegacyData.java
+++ b/src/main/java/uk/gov/mca/beacons/api/legacybeacon/domain/LegacyData.java
@@ -1,5 +1,6 @@
 package uk.gov.mca.beacons.api.legacybeacon.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.io.Serializable;
 import java.util.List;
 import lombok.*;
@@ -10,6 +11,7 @@ import uk.gov.mca.beacons.api.shared.domain.base.ValueObject;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class LegacyData implements ValueObject, Serializable {
 
   private LegacyBeaconDetails beacon;

--- a/src/main/java/uk/gov/mca/beacons/api/legacybeacon/domain/LegacyEmergencyContact.java
+++ b/src/main/java/uk/gov/mca/beacons/api/legacybeacon/domain/LegacyEmergencyContact.java
@@ -1,5 +1,6 @@
 package uk.gov.mca.beacons.api.legacybeacon.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.io.Serializable;
 import lombok.*;
 import uk.gov.mca.beacons.api.shared.domain.base.ValueObject;
@@ -9,6 +10,7 @@ import uk.gov.mca.beacons.api.shared.domain.base.ValueObject;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class LegacyEmergencyContact implements ValueObject, Serializable {
 
   private String details;

--- a/src/main/java/uk/gov/mca/beacons/api/legacybeacon/domain/LegacyOwner.java
+++ b/src/main/java/uk/gov/mca/beacons/api/legacybeacon/domain/LegacyOwner.java
@@ -1,5 +1,6 @@
 package uk.gov.mca.beacons.api.legacybeacon.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.io.Serializable;
 import lombok.*;
 import uk.gov.mca.beacons.api.shared.domain.base.ValueObject;
@@ -9,6 +10,7 @@ import uk.gov.mca.beacons.api.shared.domain.base.ValueObject;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class LegacyOwner implements ValueObject, Serializable {
 
   private String fax;

--- a/src/main/java/uk/gov/mca/beacons/api/legacybeacon/domain/LegacySecondaryOwner.java
+++ b/src/main/java/uk/gov/mca/beacons/api/legacybeacon/domain/LegacySecondaryOwner.java
@@ -1,5 +1,6 @@
 package uk.gov.mca.beacons.api.legacybeacon.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.io.Serializable;
 import lombok.*;
 import uk.gov.mca.beacons.api.shared.domain.base.ValueObject;
@@ -9,6 +10,7 @@ import uk.gov.mca.beacons.api.shared.domain.base.ValueObject;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class LegacySecondaryOwner implements ValueObject, Serializable {
 
   private String fax;

--- a/src/main/java/uk/gov/mca/beacons/api/legacybeacon/domain/LegacyUse.java
+++ b/src/main/java/uk/gov/mca/beacons/api/legacybeacon/domain/LegacyUse.java
@@ -1,5 +1,6 @@
 package uk.gov.mca.beacons.api.legacybeacon.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.io.Serializable;
 import lombok.*;
 import uk.gov.mca.beacons.api.shared.domain.base.ValueObject;
@@ -9,6 +10,7 @@ import uk.gov.mca.beacons.api.shared.domain.base.ValueObject;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class LegacyUse implements ValueObject, Serializable {
 
   private String note;


### PR DESCRIPTION
Unknown properties in legacy beacon json were preventing it from being deserialized from the database properly, added annotation to allow json serialize/deserialize library (Jackson) to ignore unknown properties.

## Link to Trello card

https://trello.com/c/1S2d02e4/472-manual-regression-testing

