### PR TITLE
Configure Elasticsearch client to work with AWS Opensearch Service

### DIFF
--- a/src/main/java/uk/gov/mca/beacons/api/configuration/OpensearchRestClientConfiguration.java
+++ b/src/main/java/uk/gov/mca/beacons/api/configuration/OpensearchRestClientConfiguration.java
@@ -25,13 +25,13 @@ public class OpensearchRestClientConfiguration
   @Value("${opensearch.port}")
   private int port;
 
-  @Value("{opensearch.credentials.enabled}")
-  private boolean credentialsEnabled;
+  @Value("${opensearch.credentials.enabled}")
+  private Boolean credentialsEnabled;
 
-  @Value("{opensearch.credentials.user}")
+  @Value("${opensearch.credentials.user:n/a}")
   private String user;
 
-  @Value("{opensearch.credentials.password}")
+  @Value("${opensearch.credentials.password:n/a}")
   private String password;
 
   @Bean

--- a/src/main/java/uk/gov/mca/beacons/api/configuration/OpensearchRestClientConfiguration.java
+++ b/src/main/java/uk/gov/mca/beacons/api/configuration/OpensearchRestClientConfiguration.java
@@ -2,8 +2,6 @@ package uk.gov.mca.beacons.api.configuration;
 
 import org.elasticsearch.client.RestHighLevelClient;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -13,17 +11,12 @@ import org.springframework.data.elasticsearch.config.AbstractElasticsearchConfig
 import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
 import org.springframework.lang.NonNull;
 
-@ConditionalOnProperty(
-  prefix = "opensearch",
-  name = "enabled",
-  havingValue = "true"
-)
 @Configuration
 @EnableElasticsearchRepositories(
   basePackages = "uk.gov.mca.beacons.api.search.repositories"
 )
 @ComponentScan(basePackages = { "uk.gov.mca.beacons.api.search" })
-public class OpenSearchRestClientConfiguration
+public class OpensearchRestClientConfiguration
   extends AbstractElasticsearchConfiguration {
 
   @Value("${opensearch.host}")
@@ -32,20 +25,39 @@ public class OpenSearchRestClientConfiguration
   @Value("${opensearch.port}")
   private int port;
 
+  @Value("{opensearch.credentials.enabled}")
+  private boolean credentialsEnabled;
+
+  @Value("{opensearch.credentials.user}")
+  private String user;
+
+  @Value("{opensearch.credentials.password}")
+  private String password;
+
   @Bean
   @NonNull
   @Override
-  @ConditionalOnProperty(
-    prefix = "opensearch",
-    name = "enabled",
-    havingValue = "true"
-  )
   public RestHighLevelClient elasticsearchClient() {
-    final ClientConfiguration clientConfiguration = ClientConfiguration
+    ClientConfiguration clientConfiguration;
+
+    if (credentialsEnabled) {
+      clientConfiguration = clientConfigurationWithBasicAuthAndSslEnabled();
+    } else {
+      clientConfiguration = clientConfigurationWithoutBasicAuth();
+    }
+    return RestClients.create(clientConfiguration).rest();
+  }
+
+  private ClientConfiguration clientConfigurationWithBasicAuthAndSslEnabled() {
+    return ClientConfiguration
       .builder()
       .connectedTo(host + ":" + port)
+      .usingSsl()
+      .withBasicAuth(user, password)
       .build();
+  }
 
-    return RestClients.create(clientConfiguration).rest();
+  private ClientConfiguration clientConfigurationWithoutBasicAuth() {
+    return ClientConfiguration.builder().connectedTo(host + ":" + port).build();
   }
 }

--- a/src/main/java/uk/gov/mca/beacons/api/search/SearchService.java
+++ b/src/main/java/uk/gov/mca/beacons/api/search/SearchService.java
@@ -2,8 +2,6 @@ package uk.gov.mca.beacons.api.search;
 
 import java.util.Objects;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 import uk.gov.mca.beacons.api.accountholder.domain.AccountHolder;
 import uk.gov.mca.beacons.api.accountholder.domain.AccountHolderId;
@@ -12,11 +10,6 @@ import uk.gov.mca.beacons.api.exceptions.ResourceNotFoundException;
 import uk.gov.mca.beacons.api.search.documents.AccountHolderDocument;
 import uk.gov.mca.beacons.api.search.repositories.AccountHolderSearchRepository;
 
-@ConditionalOnProperty(
-  prefix = "opensearch",
-  name = "enabled",
-  havingValue = "true"
-)
 @Service("Opensearch service")
 public class SearchService {
 

--- a/src/main/java/uk/gov/mca/beacons/api/search/documents/AccountHolderDocument.java
+++ b/src/main/java/uk/gov/mca/beacons/api/search/documents/AccountHolderDocument.java
@@ -5,17 +5,10 @@ import java.util.UUID;
 import javax.persistence.Id;
 import lombok.Getter;
 import lombok.Setter;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 
-@ConditionalOnProperty(
-  prefix = "opensearch",
-  name = "enabled",
-  havingValue = "true"
-)
 @Getter
 @Setter
 @Document(indexName = "account_holder")

--- a/src/main/java/uk/gov/mca/beacons/api/search/documents/BeaconSearchDocument.java
+++ b/src/main/java/uk/gov/mca/beacons/api/search/documents/BeaconSearchDocument.java
@@ -8,22 +8,15 @@ import java.util.stream.Collectors;
 import javax.persistence.Id;
 import lombok.Getter;
 import lombok.Setter;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 import uk.gov.mca.beacons.api.beacon.domain.Beacon;
 import uk.gov.mca.beacons.api.beaconowner.domain.BeaconOwner;
 import uk.gov.mca.beacons.api.beaconuse.domain.BeaconUse;
-import uk.gov.mca.beacons.api.legacybeacon.domain.LegacyBeacon;
 import uk.gov.mca.beacons.api.search.documents.nested.NestedBeaconOwner;
 import uk.gov.mca.beacons.api.search.documents.nested.NestedBeaconUse;
 
-@ConditionalOnProperty(
-  prefix = "opensearch",
-  name = "enabled",
-  havingValue = "true"
-)
 @Getter
 @Setter
 @Document(indexName = "beacon_search")

--- a/src/main/java/uk/gov/mca/beacons/api/search/listeners/AccountHolderListener.java
+++ b/src/main/java/uk/gov/mca/beacons/api/search/listeners/AccountHolderListener.java
@@ -1,19 +1,12 @@
 package uk.gov.mca.beacons.api.search.listeners;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 import uk.gov.mca.beacons.api.accountholder.domain.events.AccountHolderCreated;
 import uk.gov.mca.beacons.api.accountholder.domain.events.AccountHolderUpdated;
 import uk.gov.mca.beacons.api.search.SearchService;
 
-@ConditionalOnProperty(
-  prefix = "opensearch",
-  name = "enabled",
-  havingValue = "true"
-)
 @Component
 public class AccountHolderListener {
 

--- a/src/main/java/uk/gov/mca/beacons/api/search/repositories/AccountHolderSearchRepository.java
+++ b/src/main/java/uk/gov/mca/beacons/api/search/repositories/AccountHolderSearchRepository.java
@@ -1,15 +1,8 @@
 package uk.gov.mca.beacons.api.search.repositories;
 
 import java.util.UUID;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 import uk.gov.mca.beacons.api.search.documents.AccountHolderDocument;
 
-@ConditionalOnProperty(
-  prefix = "opensearch",
-  name = "enabled",
-  havingValue = "true"
-)
 public interface AccountHolderSearchRepository
   extends ElasticsearchRepository<AccountHolderDocument, UUID> {}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,4 +1,7 @@
 opensearch:
-  host: localhost
-  port: 9200
-  enabled: true
+  source:
+    host: localhost
+    port: 9200
+    https: false
+  credentials:
+    enabled: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,6 +53,11 @@ azure:
     app-id-uri: ${AZURE_AD_API_ID_URI:api://8fb0f9ea-6351-4251-bcca-85e298bda8e7}
 
 opensearch:
-  host: localhost
-  port: 9200
-  enabled: false
+  source:
+    host: ${OPENSEARCH_ENDPOINT}
+    port: 443
+    https: true
+  credentials:
+    enabled: true
+    user: ${OPENSEARCH_USER}
+    password: ${OPENSEARCH_PASSWORD}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -40,6 +40,9 @@ beacons:
         password: password
 
 opensearch:
-  host: localhost
-  port: 9200
-  enabled: true
+  source:
+    host: localhost
+    port: 9200
+    https: false
+  credentials:
+    enabled: false


### PR DESCRIPTION
## Context

Updates to the Elasticsearch client configuration necessary for the Beacon Service API to communicate with AWS Opensearch Service

## Link to Trello card

https://trello.com/c/CL3Z2wtB/469-as-a-service-owner-i-want-opensearch-to-be-stood-up-via-infrastructure-as-code